### PR TITLE
refactor(Endpoints)!: change Endpoint interface formats

### DIFF
--- a/src/interactions/Interactions.ts
+++ b/src/interactions/Interactions.ts
@@ -1,7 +1,9 @@
 import type { Nullable, TupleOf } from '@api-typings/core';
 import type {
 	AllowedMentions,
+	EditWebhookMessage,
 	Embed,
+	ExecuteWebhook,
 	GuildMember,
 	PartialChannel,
 	PartialGuildMember,
@@ -368,80 +370,171 @@ export interface MessageInteraction {
 
 // SECTION Endpoints
 
-// ANCHOR Create
+/**
+ * Fetch all of the global commands for your application.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands) `/applications/{application.id}/commands`
+ */
+export type GetGlobalApplicationCommands = { response: ApplicationCommand[] };
 
 /**
- * Create a new guild/global command.
- * - **Guild:** new guild commands will be available in the guild immediately.
- * - **Global:** new global commands will be available in all guilds after 1 hour.
- *
- * @info
- * Apps can have a maximum of 100 global commands, and an additional 100 guild-specific commands per
- * guild.
+ * Creates a new global command. New global commands will be available in all guilds after 1 hour.
  *
  * @warning
- * Creating a command with the same name as an existing command for your application will
- * overwrite the old command.
+ * Creating a command with the same name as an existing command for your application will overwrite
+ * the old command.
  *
- * @endpoint POST [[1][P1]] [[2][P2]]
- * - **Guild:** `/applications/{application.id}/guilds/{guild.id}/commands`
- * - **Global:** `/applications/{application.id}/commands`
- *
- * @returns `201` and an [Application Command][1] object.
- *
- * [P1]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
- * [P2]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
- * [1]: https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
+ * @endpoint [POST](https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command) `/applications/{application.id}/commands`
  */
-export interface CreateApplicationCommand {
-	/**
-	 * 1-32 character name matching `^[\w-]{1,32}$`.
-	 */
-	name: string;
+export interface CreateGlobalApplicationCommand {
+	body: {
+		/**
+		 * 1-32 character name matching `^[\w-]{1,32}$`.
+		 */
+		name: string;
 
-	/**
-	 * 1-100 character description.
-	 */
-	description: string;
+		/**
+		 * 1-100 character description.
+		 */
+		description: string;
 
-	/**
-	 * The parameters for the command.
-	 */
-	options?: ApplicationCommandOption[];
+		/**
+		 * The parameters for the command.
+		 */
+		options?: ApplicationCommandOption[];
+	};
+
+	response: ApplicationCommand;
 }
-
-// ANCHOR Edit
 
 /**
- * Edit a guild/global command.
- * - **Guild:** updates for guild commands will be available immediately.
- * - **Global:** updates will be available in all guilds after 1 hour.
+ * Fetch a global command for your application.
  *
- * @endpoint PATCH [[1][P1]] [[2][P2]]
- * - **Guild:** `/applications/{application.id}/guilds/{guild.id}/commands/{command.id}`
- * - **Global:** `/applications/{application.id}/commands/{command.id}`
- *
- * @returns `200` and an [Application Command][1] object.
- *
- * [P1]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
- * [P2]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
- * [1]: https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
+ * @endpoint [GET](https://discord.com/developers/docs/interactions/slash-commands#get-global-application-command) `/applications/{application.id}/commands/{command.id}`
  */
-export interface EditApplicationCommand {
-	/**
-	 * 1-32 character name matching `^[\w-]{1,32}$`.
-	 */
-	name?: string;
+export type GetGlobalApplicationCommand = { response: ApplicationCommand };
 
-	/**
-	 * 1-100 character description.
-	 */
-	description?: string;
+/**
+ * Edit a global command. Updates will be available in all guilds after 1 hour.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command) `/applications/{application.id}/commands/{command.id}`
+ */
+export interface EditGlobalApplicationCommand {
+	body: {
+		/**
+		 * 1-32 character name matching `^[\w-]{1,32}$`.
+		 */
+		name?: string;
 
-	/**
-	 * The parameters for the command.
-	 */
-	options?: Nullable<ApplicationCommandOption[]>;
+		/**
+		 * 1-100 character description.
+		 */
+		description?: string;
+
+		/**
+		 * The parameters for the command.
+		 */
+		options?: Nullable<ApplicationCommandOption>[];
+	};
+
+	response: ApplicationCommand;
 }
+
+/**
+ * Deletes a global command.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/interactions/slash-commands#delete-global-application-command) `/applications/{application.id}/commands/{command.id}`
+ */
+export type DeleteGlobalApplicationCommand = { response: never };
+
+/**
+ * Fetch all of the guild commands for your application for a specific guild.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-commands) `/applications/{application.id}/guilds/{guild.id}/commands`
+ */
+export type GetGuildApplicationCommands = { response: ApplicationCommand[] };
+
+/**
+ * Create a new guild command. New guild commands will be available in the guild immediately.
+ *
+ * @warning
+ * Creating a command with the same name as an existing command for your application will overwrite
+ * the old command.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command) `/applications/{application.id}/guilds/{guild.id}/commands`
+ */
+export interface CreateGuildApplicationCommand {
+	body: CreateGlobalApplicationCommand['body'];
+	response: ApplicationCommand;
+}
+
+/**
+ * Fetch a guild command for your application.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-command) `/applications/{application.id}/guilds/{guild.id}/commands/{command.id}`
+ */
+export type GetGuildApplicationCommand = { response: ApplicationCommand };
+
+/**
+ * Edit a guild command. Updates for guild commands will be available immediately.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command) `/applications/{application.id}/guilds/{guild.id}/commands/{command.id}`
+ */
+export interface EditGuildApplicationCommand {
+	body: EditGlobalApplicationCommand['body'];
+	response: ApplicationCommand;
+}
+
+/**
+ * Delete a guild command.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/interactions/slash-commands#delete-guild-application-command) `/applications/{application.id}/guilds/{guild.id}/commands/{command.id}`
+ */
+export type DeleteGuildApplicationCommand = { response: never };
+
+/**
+ * Create a response to an Interaction from the gateway.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response) `/interactions/{interaction.id}/{interaction.token}/callback`
+ */
+export interface CreateInteractionResponse {
+	body: InteractionResponse;
+	response: never;
+}
+
+/**
+ * Edits the initial Interaction response.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response) `/webhooks/{application.id}/{interaction.token}/messages/@original`
+ */
+export type EditOriginalInteractionResponse = EditWebhookMessage;
+
+/**
+ * Deletes the initial Interaction response.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response) `/webhooks/{application.id}/{interaction.token}/messages/@original`
+ */
+export type DeleteOriginalInteractionResponse = { response: never };
+
+/**
+ * Create a followup message for an Interaction.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/interactions/slash-commands#create-followup-message) `/webhooks/{application.id}/{interaction.token}`
+ */
+export type CreateFollowupMessage = ExecuteWebhook['body'];
+
+/**
+ * Edits a followup message for an Interaction.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message) `/webhooks/{application.id}/{interaction.token}/messages/{message.id}`
+ */
+export type EditFollowupMessage = EditWebhookMessage;
+
+/**
+ * Deletes a followup message for an Interaction.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/interactions/slash-commands#delete-followup-message) `/webhooks/{application.id}/{interaction.token}/messages/{message.id}`
+ */
+export type DeleteFollowupMessage = { response: never };
 
 // !SECTION

--- a/src/resources/AuditLog.ts
+++ b/src/resources/AuditLog.ts
@@ -295,35 +295,36 @@ export interface AuditLogChangeKey {
  *
  * @endpoint [GET] `/guilds/{guild.id}/audit-logs`
  *
- * @returns An [audit log][1] object for the guild.
- *
  * [GET]: https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
- * [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-object
  */
 export interface GetGuildAuditLog {
-	/**
-	 * Filter the log for actions made by a user.
-	 */
-	user_id?: Snowflake;
+	query: {
+		/**
+		 * Filter the log for actions made by a user.
+		 */
+		user_id?: Snowflake;
 
-	/**
-	 * The type of [audit log event][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
-	 */
-	action_type?: AuditLogEvent;
+		/**
+		 * The type of [audit log event][1].
+		 *
+		 * [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
+		 */
+		action_type?: AuditLogEvent;
 
-	/**
-	 * Filter the log before a certain entry ID.
-	 */
-	before?: Snowflake;
+		/**
+		 * Filter the log before a certain entry ID.
+		 */
+		before?: Snowflake;
 
-	/**
-	 * How many entries are returned.
-	 *
-	 * @defaultValue 50
-	 */
-	limit?: RangeOf<1, 100>;
+		/**
+		 * How many entries are returned.
+		 *
+		 * @defaultValue 50
+		 */
+		limit?: RangeOf<1, 100>;
+	};
+
+	response: AuditLog;
 }
 
 // !SECTION

--- a/src/resources/AuditLog.ts
+++ b/src/resources/AuditLog.ts
@@ -293,9 +293,7 @@ export interface AuditLogChangeKey {
 /**
  * Requires the `VIEW_AUDIT_LOG` permission.
  *
- * @endpoint [GET] `/guilds/{guild.id}/audit-logs`
- *
- * [GET]: https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
+ * @endpoint [GET](https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log) `/guilds/{guild.id}/audit-logs`
  */
 export interface GetGuildAuditLog {
 	query: {

--- a/src/resources/AuditLog.ts
+++ b/src/resources/AuditLog.ts
@@ -303,9 +303,7 @@ export interface GetGuildAuditLog {
 		user_id?: Snowflake;
 
 		/**
-		 * The type of [audit log event][1].
-		 *
-		 * [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events
+		 * The type of audit log event.
 		 */
 		action_type?: AuditLogEvent;
 

--- a/src/resources/Channel.ts
+++ b/src/resources/Channel.ts
@@ -1,5 +1,6 @@
 import type { Nullable, RangeOf } from '@api-typings/core';
 import type { GuildMember, InviteTargetType, MessageInteraction, PartialEmoji, Snowflake, User } from '../';
+import { Invite, InviteMetadata } from './Invite';
 
 // SECTION Channel Types
 
@@ -1079,149 +1080,196 @@ export enum OverwriteType {
 // SECTION Endpoints
 
 /**
- * Update a channel's settings. Requires the `MANAGE_CHANNELS` permission for the guild. Only
- * permissions your bot has in the guild or channel can be allowed/denied (unless your bot has a
- * `MANAGE_ROLES` overwrite in the channel).
+ * Get a channel by ID.
  *
- * @endpoint [PATCH] `/channels/{channel.id}`
+ * @endpoint [GET](https://discord.com/developers/docs/resources/channel#get-channel) `/channels/{channel.id}`
+ */
+export type GetChannel = { response: Channel };
+
+/**
+ * Update a channel's settings. Requires the `MANAGE_CHANNELS` permission.
  *
- * @returns A [channel][1] on success, and a `400 BAD REQUEST` on invalid parameters.
- * @fires A [Channel Update][2] Gateway event.  If modifying a category, individual [Channel
- * Update][2] events will fire for each child channel that also changes. If modifying permission
- * overwrites, the `MANAGE_ROLES` permission is required.
+ * If modifying permission overwrites, the MANAGE_ROLES permission is required. Only permissions
+ * your bot has in the guild or channel can be allowed/denied (unless your bot has a `MANAGE_ROLES`
+ * overwrite in the channel).
  *
- * [PATCH]: https://discord.com/developers/docs/resources/channel#modify-channel
- * [1]: https://discord.com/developers/docs/resources/channel#channel-object
- * [2]: https://discord.com/developers/docs/topics/gateway#channel-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/channel#modify-channel) `/channels/{channel.id}`
  */
 export interface ModifyChannel {
-	/**
-	 * 2-100 character channel name.
-	 *
-	 * @channel All
-	 */
-	name?: string;
+	body: {
+		/**
+		 * 2-100 character channel name.
+		 *
+		 * @channel All
+		 */
+		name?: string;
 
-	/**
-	 * The [type of Channel][1]; only conversion between text and news is supported and only in
-	 * guilds with the `NEWS` feature.
-	 *
-	 * @channel Text, News
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/channel#channel-object-channel-types
-	 */
-	type?: number | ChannelType;
+		/**
+		 * The type of Channel; only conversion between text and news is supported and only in
+		 * guilds with the `NEWS` feature.
+		 *
+		 * @channel Text, News
+		 */
+		type?: number | ChannelType;
 
-	/**
-	 * The position of the channel in the left-hand listing.
-	 *
-	 * @channel All
-	 */
-	position?: Nullable<number>;
+		/**
+		 * The position of the channel in the left-hand listing.
+		 *
+		 * @channel All
+		 */
+		position?: Nullable<number>;
 
-	/**
-	 * 0-1024 character channel topic.
-	 *
-	 * @channel Text, News
-	 */
-	topic?: Nullable<string>;
+		/**
+		 * 0-1024 character channel topic.
+		 *
+		 * @channel Text, News
+		 */
+		topic?: Nullable<string>;
 
-	/**
-	 * Whether the channel is NSFW.
-	 *
-	 * @channel Text, News, Store
-	 */
-	nsfw?: Nullable<boolean>;
+		/**
+		 * Whether the channel is NSFW.
+		 *
+		 * @channel Text, News, Store
+		 */
+		nsfw?: Nullable<boolean>;
 
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600); bots, as
-	 * well as users with the permission `manage_messages` or `manage_channel`, are unaffected.
-	 *
-	 * @channel Text
-	 */
-	rate_limit_per_user?: Nullable<number>;
+		/**
+		 * Amount of seconds a user has to wait before sending another message (0-21600); bots, as
+		 * well as users with the permission `manage_messages` or `manage_channel`, are unaffected.
+		 *
+		 * @channel Text
+		 */
+		rate_limit_per_user?: Nullable<number>;
 
-	/**
-	 * The bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers).
-	 *
-	 * @channel Voice
-	 */
-	bitrate?: Nullable<number>;
+		/**
+		 * The bitrate (in bits) of the voice channel; 8000 to 96000 (128000 for VIP servers).
+		 *
+		 * @channel Voice
+		 */
+		bitrate?: Nullable<number>;
 
-	/**
-	 * The user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user limit.
-	 *
-	 * @channel Voice
-	 */
-	user_limit?: Nullable<RangeOf<0, 99>>;
+		/**
+		 * The user limit of the voice channel; 0 refers to no limit, 1 to 99 refers to a user
+		 * limit.
+		 *
+		 * @channel Voice
+		 */
+		user_limit?: Nullable<RangeOf<0, 99>>;
 
-	/**
-	 * Channel or category-specific permissions.
-	 *
-	 * @channel All
-	 */
-	permission_overwrites?: Nullable<Overwrite[]>;
+		/**
+		 * Channel or category-specific permissions.
+		 *
+		 * @channel All
+		 */
+		permission_overwrites?: Nullable<Overwrite[]>;
 
-	/**
-	 * ID of the new parent category for a channel.
-	 *
-	 * @channel Text, News, Store, Voice
-	 */
-	parent_id?: Nullable<Snowflake>;
+		/**
+		 * ID of the new parent category for a channel.
+		 *
+		 * @channel Text, News, Store, Voice
+		 */
+		parent_id?: Nullable<Snowflake>;
 
-	/**
-	 * Image for the channel icon.
-	 *
-	 * @channel Group DM
-	 */
-	icon?: string;
+		/**
+		 * Image for the channel icon.
+		 *
+		 * @channel Group DM
+		 */
+		icon?: string;
+	};
+
+	response: Channel;
 }
 
 /**
- * Returns the messages for a channel. If operating on a guild channel, this endpoint requires the
- * `VIEW_CHANNEL` permission to be present on the current user. If the current user is missing the
- * `READ_MESSAGE_HISTORY` permission in the channel then this will return no messages (since they
- * cannot read the message history).
+ * Delete a channel. Requires the `MANAGE_CHANNELS` permission.
  *
- * @endpoint [GET] `/channels/{channel.id}/messages`
+ * Deleting a category does not delete its child channels; they will have their `parent_id` removed.
  *
- * @returns An array of [message][1] objects on success, sorted by their ID in descending order.
+ * @info
+ * For Community guilds, the Rules or Guidelines channel and the Community Updates channel cannot
+ * be deleted.
  *
- * [GET]: https://discord.com/developers/docs/resources/channel#get-channel-messages
- * [1]: https://discord.com/developers/docs/resources/channel#message-object
+ * @warning
+ * Deleting a guild channel cannot be undone. Use this with caution, as it is impossible to undo
+ * this action.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#deleteclose-channel) `/channels/{channel.id}`
+ */
+export type DeleteChannel = { response: Channel };
+
+/**
+ * Close a private message.
+ *
+ * @info
+ * It is possible to undo this action by opening a private message with the recipient again.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#deleteclose-channel) `/channels/{channel.id}`
+ */
+export type CloseChannel = { response: Channel };
+
+/**
+ * Returns the messages for a channel.
+ *
+ * - If operating on a guild channel, this endpoint requires the `VIEW_CHANNEL` permission to be
+ * present on the current user.
+ * - If the current user is missing the `READ_MESSAGE_HISTORY` permission in the channel then this
+ * will return no messages (since they cannot read the message history).
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/channel#get-channel-messages) `/channels/{channel.id}/messages`
  */
 export interface GetChannelMessages {
 	/**
-	 * Get messages around this message ID.
+	 * @info
+	 * The before, after, and around keys are mutually exclusive, only one may be passed at a time.
 	 */
-	around?: Snowflake;
+	query: {
+		/**
+		 * Get messages around this message ID.
+		 */
+		around?: Snowflake;
+
+		/**
+		 * Get messages before this message ID.
+		 */
+		before?: Snowflake;
+
+		/**
+		 * Get messages after this message ID.
+		 */
+		after?: Snowflake;
+
+		/**
+		 * Max number of messages to return (1-100).
+		 *
+		 * @defaultValue 50
+		 */
+		limit?: RangeOf<1, 100>;
+	};
 
 	/**
-	 * Get messages before this message ID.
+	 * An array of message objects, sorted by their ID in descending order.
 	 */
-	before?: Snowflake;
-
-	/**
-	 * Get messages after this message ID.
-	 */
-	after?: Snowflake;
-
-	/**
-	 * Max number of messages to return (1-100).
-	 *
-	 * @defaultValue 50
-	 */
-	limit?: RangeOf<1, 100>;
+	response: Message[] | [];
 }
+
+/**
+ * Returns a specific message in the channel.
+ *
+ * If operating on a guild channel, this endpoint requires the `READ_MESSAGE_HISTORY` permission to
+ * be present on the current user.
+ */
+export type GetChannelMessage = { response: Message };
 
 // SECTION Create Message
 
 // ANCHOR JSON
 
 /**
- * Post a message to a guild text or DM channel. You may create a message as a reply to another
- * message. To do so, include a [`message_reference`][1] with a `message_id`. The `channel_id` and
- * `guild_id` in the `message_reference` are optional, but will be validated if provided.
+ * Post a message to a guild text or DM channel.
+ *
+ * @info
+ * Note that when sending `application/json` you must send at **least one of** `content` or `embed`.
  *
  * @limitations
  * - When operating on a guild channel, the current user must have the `SEND_MESSAGES` permission
@@ -1236,46 +1284,40 @@ export interface GetChannelMessages {
  *   for images,
  * - **Files can only be uploaded when using the `multipart/form-data` content type**,
  *
- * @endpoint [POST] `/channels/{channel.id}/messages`
- *
- * @returns A [message][2] object.
- * @fires A [Message Create][3] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/channel#create-message
- * [1]: https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure
- * [2]: https://discord.com/developers/docs/resources/channel#message-object
- * [3]: https://discord.com/developers/docs/topics/gateway#message-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#create-message) `/channels/{channel.id}/messages`
  */
 export interface CreateMessageJSON {
-	/**
-	 * The message contents (up to 2000 characters).
-	 */
-	content?: string;
+	body: {
+		/**
+		 * The message contents (up to 2000 characters).
+		 */
+		content?: string;
 
-	/**
-	 * A nonce that can be used for optimistic message sending.
-	 */
-	nonce?: number | string;
+		/**
+		 * A nonce that can be used for optimistic message sending.
+		 */
+		nonce?: number | string;
 
-	/**
-	 * True if this is a TTS message.
-	 */
-	tts?: boolean;
+		/**
+		 * True if this is a TTS message.
+		 */
+		tts?: boolean;
 
-	/**
-	 * Embedded rich content.
-	 */
-	embed?: Embed;
+		/**
+		 * Embedded rich content.
+		 */
+		embed?: Embed;
 
-	/**
-	 * Allowed mentions for a message.
-	 */
-	allowed_mentions?: AllowedMentions;
+		/**
+		 * Allowed mentions for a message.
+		 */
+		allowed_mentions?: AllowedMentions;
 
-	/**
-	 * Include to make your message a reply.
-	 */
-	message_reference?: MessageReference;
+		/**
+		 * Include to make your message a reply.
+		 */
+		message_reference?: MessageReference;
+	};
 }
 
 // ANCHOR Form-Data
@@ -1284,21 +1326,15 @@ export interface CreateMessageJSON {
  * Post a message to a guild text or DM channel.
  *
  * @remarks
- * - Some fields can be provided as `form-data` fields, but **if you supply a `payload_json`, all
- *   fields except for `file` fields will be ignored**.
- * - You may create a message as a reply to another message. To do so, include a
- *   [`message_reference`][1] with a `message_id`.
- *   The `channel_id` and `guild_id` in the `message_reference` are optional, but will be validated
- *   if provided.
+ * This endpoint supports all the same fields as its `application/json` counterpart, however they
+ * must be set in `payload_json` rather than provided as form fields. Some fields can be provided
+ * as `form-data` fields, but if you supply a `payload_json`, **all fields except for `file` fields
+ * will be ignored**.
  *
  * @info
  * Note that when sending `multipart/form-data`, you must provide a value for at **least one of**
  * `content`, `embed` or `file`. For a `file` attachment, the `Content-Disposition` subpart header
  * MUST contain a `filename` parameter.
- *
- * @warning
- * This endpoint supports **all** the same fields as its `application/json` counterpart, however
- * they must be set in `payload_json` rather than provided as form fields.
  *
  * @limitations
  * - When operating on a guild channel, the current user must have the `SEND_MESSAGES` permission
@@ -1311,72 +1347,127 @@ export interface CreateMessageJSON {
  * - For the embed object, you can set every field except `type` (it will be `rich` regardless of
  *   if you try to set it), `provider`, `video`, and any `height`, `width`, or `proxy_url` values
  *   for images
- * - **Files can only be uploaded when using the `multipart/form-data` content type**
  *
- * @endpoint [POST] `/channels/{channel.id}/messages`
- *
- * @returns A [message][2] object.
- * @fires A [Message Create][3] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/channel#create-message
- * [1]: https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure
- * [2]: https://discord.com/developers/docs/resources/channel#message-object
- * [3]: https://discord.com/developers/docs/topics/gateway#message-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#create-message) `/channels/{channel.id}/messages`
  */
 export interface CreateMessageFormData {
-	/**
-	 * The message contents (up to 2000 characters).
-	 */
-	content?: string;
+	body: {
+		/**
+		 * The message contents (up to 2000 characters).
+		 */
+		content?: string;
 
-	/**
-	 * A nonce that can be used for optimistic message sending.
-	 */
-	nonce?: number | string;
+		/**
+		 * A nonce that can be used for optimistic message sending.
+		 */
+		nonce?: number | string;
 
-	/**
-	 * True if this is a TTS message.
-	 */
-	tts?: boolean;
+		/**
+		 * True if this is a TTS message.
+		 */
+		tts?: boolean;
 
-	/**
-	 * The contents of the file being sent.
-	 */
-	file?: unknown;
+		/**
+		 * The contents of the file being sent.
+		 */
+		file?: unknown;
 
-	/**
-	 * JSON encoded body of any additional request fields.
-	 */
-	payload_json?: string;
+		/**
+		 * JSON encoded body of any additional request fields.
+		 */
+		payload_json?: string;
+	};
+
+	response: Message;
 }
 
 // !SECTION
 
 /**
- * Get a list of users that reacted with this emoji. The `emoji` must be [URL Encoded][1] or the
- * request will fail with `10014: Unknown Emoji`.
+ * Crosspost a message in a News Channel to following channels. This endpoint requires the
+ * `SEND_MESSAGES` permission, if the current user sent the message, or additionally the
+ * `MANAGE_MESSAGES` permission, for all other messages, to be present for the current user.
  *
- * @endpoint [GET] `/channels/{channel.id}/messages/{message.id}/reactions/{emoji.id}`
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#crosspost-message) `/channels/{channel.id}/messages/{message.id}/crosspost`
+ */
+export type CrosspostMessage = { response: Message };
+
+/**
+ * Create a reaction for the message. This endpoint requires the `READ_MESSAGE_HISTORY` permission
+ * to be present on the current user. Additionally, if nobody else has reacted to the message using
+ * this emoji, this endpoint requires the `ADD_REACTIONS` permission to be present on the current
+ * user.
  *
- * @returns An array of [user][2] objects on success, sorted by their ID in ascending order.
+ * The `emoji` must be URL Encoded or the request will fail with `10014: Unknown Emoji`.
  *
- * [GET]: https://discord.com/developers/docs/resources/channel#get-reactions
- * [1]: https://en.wikipedia.org/wiki/Percent-encoding
- * [2]: https://discord.com/developers/docs/resources/user#user-object
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/channel#create-reaction) `/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me`
+ */
+export type CreateReaction = { response: never };
+
+/**
+ * Delete a reaction the current user has made for the message.
+ *
+ * The `emoji` must be URL Encoded or the request will fail with `10014: Unknown Emoji`.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-own-reaction) `/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me`
+ */
+export type DeleteOwnReaction = { response: never };
+
+/**
+ * Deletes another user's reaction. This endpoint requires the `MANAGE_MESSAGES` permission to be
+ * present on the current user.
+ *
+ * The `emoji` must be URL Encoded or the request will fail with `10014: Unknown Emoji`.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-user-reaction) `/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}`
+ */
+export type DeleteUserReaction = { response: never };
+
+/**
+ * Get a list of users that reacted with this emoji.
+ *
+ * The `emoji` must be URL Encoded or the request will fail with `10014: Unknown Emoji`.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/channel#get-reactions) `/channels/{channel.id}/messages/{message.id}/reactions/{emoji.id}`
  */
 export interface GetReactions {
-	/**
-	 * Get users after this user ID.
-	 */
-	after?: Snowflake;
+	query: {
+		/**
+		 * Get users after this user ID.
+		 */
+		after?: Snowflake;
+
+		/**
+		 * Max number of users to return (1-100).
+		 *
+		 * @defaultValue 25
+		 */
+		limit?: RangeOf<1, 100>;
+	};
 
 	/**
-	 * Max number of users to return (1-100).
-	 *
-	 * @defaultValue 25
+	 * An array of user objects, sorted by their ID in ascending order.
 	 */
-	limit?: RangeOf<1, 100>;
+	response: User[];
 }
+
+/**
+ * Deletes all reactions on a message. This endpoint requires the `MANAGE_MESSAGES` permission to
+ * be present on the current user.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-all-reactions) `/channels/{channel.id}/messages/{message.id}/reactions`
+ */
+export type DeleteAllReactions = { response: never };
+
+/**
+ * Deletes all the reactions for a given emoji on a message. This endpoint requires the
+ * `MANAGE_MESSAGES` permission to be present on the current user.
+ *
+ * The `emoji` must be URL Encoded or the request will fail with `10014: Unknown Emoji`.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji) `/channels/{channel.id}/messages/{message.id}/reactions/{emoji}`
+ */
+export type DeleteAllEmojiReactions = { response: never };
 
 /**
  * Edit a previously sent message.
@@ -1389,38 +1480,39 @@ export interface GetReactions {
  * the table below may be modified by users (unsupported flag changes are currently ignored without
  * error).
  *
- * @endpoint [PATCH] `/channels/{channel.id}/messages/{message.id}`
- *
- * @returns A [message][1] object.
- * @fires A [Message Update][2] gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/channel#edit-message
- * [1]: https://discord.com/developers/docs/resources/channel#message-object
- * [2]: https://discord.com/developers/docs/topics/gateway#message-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/channel#edit-message) `/channels/{channel.id}/messages/{message.id}`
  */
 export interface EditMessage {
-	/**
-	 * The new message contents (up to 2000 characters),
-	 */
-	content?: Nullable<string>;
+	body: {
+		/**
+		 * The new message contents (up to 2000 characters),
+		 */
+		content?: Nullable<string>;
 
-	/**
-	 * Embedded `rich` content,
-	 */
-	embed?: Nullable<Embed>;
+		/**
+		 * Embedded `rich` content,
+		 */
+		embed?: Nullable<Embed>;
 
-	/**
-	 * Edit the [flags][1] of a message (only `SUPPRESS_EMBEDS` can currently be set/unset).
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/channel#message-object-message-flags
-	 */
-	flags?: Nullable<number>;
+		/**
+		 * Edit the flags of a message (only `SUPPRESS_EMBEDS` can currently be set/unset).
+		 */
+		flags?: Nullable<number>;
 
-	/**
-	 * Allowed mentions for the message.
-	 */
-	allowed_mentions?: Nullable<AllowedMentions>;
+		/**
+		 * Allowed mentions for the message.
+		 */
+		allowed_mentions?: Nullable<AllowedMentions>;
+	};
 }
+
+/**
+ * Delete a message.
+ *
+ * If operating on a guild channel and trying to delete a message that was not sent by the current
+ * user, this endpoint requires the `MANAGE_MESSAGES` permission.
+ */
+export type DeleteMessage = { response: never };
 
 /**
  * Delete multiple messages in a single request. This endpoint can only be used on guild channels
@@ -1433,149 +1525,207 @@ export interface EditMessage {
  * This endpoint will not delete messages older than 2 weeks, and will fail with a `400 BAD REQUEST`
  * if any message provided is older than that or if any duplicate message IDs are provided.
  *
- * @endpoint [POST] `/channels/{channel.id}/messages/bulk-delete`
- *
- * @returns A `204` empty response on success.
- * @fires A [Message Delete][1] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
- * [1]: https://discord.com/developers/docs/topics/gateway#message-delete-bulk
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#bulk-delete-messages) `/channels/{channel.id}/messages/bulk-delete`
  */
 export interface BulkDeleteMessages {
-	/**
-	 * An array of message IDs to delete (2-100).
-	 */
-	messages: Snowflake[];
+	body: {
+		/**
+		 * An array of message IDs to delete (2-100).
+		 */
+		messages: Snowflake[];
+	};
+
+	response: never;
 }
 
 /**
- * Edit the channel permission overwrites for a user or role in a channel. Only usable for guild
- * channels. Requires the `MANAGE_ROLES` permission. Only permissions your bot has in the guild or
- * channel can be allowed/denied (unless your bot has a `MANAGE_ROLES` overwrite in the channel).
+ * Edit the channel permission overwrites for a user or role in a channel. Requires the
+ * `MANAGE_ROLES` permission. Only usable for guild channels.
  *
- * @endpoint [PUT] `/channels/{channel.id}/permissions/{overwrite.id}`
+ * Only permissions your bot has in the guild or channel can be
+ * allowed/denied (unless your bot has a `MANAGE_ROLES` overwrite in the channel).
  *
- * @returns A `204` empty response on success.
- *
- * [PUT]: https://discord.com/developers/docs/resources/channel#edit-channel-permissions
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/channel#edit-channel-permissions) `/channels/{channel.id}/permissions/{overwrite.id}`
  */
 export interface EditChannelPermissions {
-	/**
-	 * The bitwise value of all allowed permissions.
-	 */
-	allow?: string;
+	body: {
+		/**
+		 * The bitwise value of all allowed permissions.
+		 */
+		allow?: string;
 
-	/**
-	 * The bitwise value of all disallowed permissions.
-	 */
-	deny?: string;
+		/**
+		 * The bitwise value of all disallowed permissions.
+		 */
+		deny?: string;
 
-	/**
-	 * 0 for a role or 1 for a member.
-	 */
-	type?: 0 | 1;
+		/**
+		 * 0 for a role or 1 for a member.
+		 */
+		type?: 0 | 1;
+	};
+
+	response: never;
 }
 
 /**
- * Create a new [invite][1] object for the channel. Only usable for guild channels. Requires the
- * `CREATE_INSTANT_INVITE` permission.
+ * Returns a list of invite objects (with invite metadata) for the channel. Requires the
+ * `MANAGE_CHANNELS` permission. Only usable for guild channels.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/channel#get-channel-invites) `/channels/{channel.id}/invites`
+ */
+export type GetChannelInvites = { response: InviteMetadata[] };
+
+/**
+ * Create a new invite object for the channel. Requires the `CREATE_INSTANT_INVITE` permission. Only
+ * usable for guild channels.
  *
  * @remarks
  * All JSON parameters for this route are optional, however the request body is not. If you are not
  * sending any fields, you still have to send an empty JSON object (`{}`).
  *
- * @endpoint [POST] `/channels/{channel.id}/invites`
- *
- * @returns An [invite][1] object.
- * @fires An [Invite Create][2] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/channel#create-channel-invite
- * [1]: https://discord.com/developers/docs/resources/invite#invite-object
- * [2]: https://discord.com/developers/docs/topics/gateway#invite-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#create-channel-invite) `/channels/{channel.id}/invites`
  */
 export interface CreateChannelInvite {
-	/**
-	 * Duration of invite in seconds before expiry, or 0 for never. Between 0 and 604800 (7 days).
-	 *
-	 * @defaultValue 86400 (24 hours)
-	 */
-	max_age?: number;
+	body: {
+		/**
+		 * Duration of invite in seconds before expiry, or 0 for never. Between 0 and 604800 (7
+		 * days).
+		 *
+		 * @defaultValue 86400 (24 hours)
+		 */
+		max_age?: number;
 
-	/**
-	 * Max number of uses or 0 for unlimited. Between 0 and 100.
-	 *
-	 * @defaultValue 0
-	 */
-	max_uses?: RangeOf<0, 100>;
+		/**
+		 * Max number of uses or 0 for unlimited. Between 0 and 100.
+		 *
+		 * @defaultValue 0
+		 */
+		max_uses?: RangeOf<0, 100>;
 
-	/**
-	 * Whether this invite only grants temporary membership.
-	 *
-	 * @defaultValue false
-	 */
-	temporary?: boolean;
+		/**
+		 * Whether this invite only grants temporary membership.
+		 *
+		 * @defaultValue false
+		 */
+		temporary?: boolean;
 
-	/**
-	 * If true, don't try to reuse a similar invite (useful for creating many unique one time use
-	 * invites).
-	 *
-	 * @defaultValue false
-	 */
-	unique?: boolean;
+		/**
+		 * If true, don't try to reuse a similar invite (useful for creating many unique one time
+		 * use invites).
+		 *
+		 * @defaultValue false
+		 */
+		unique?: boolean;
 
-	/**
-	 * The type of target for this voice channel invite.
-	 */
-	target_type?: InviteTargetType;
+		/**
+		 * The type of target for this voice channel invite.
+		 */
+		target_type?: InviteTargetType;
 
-	/**
-	 * The ID of the user whose stream to display for this invite, required if `target_type` is 1,
-	 * the user must be streaming in the channel.
-	 */
-	target_user_id?: Snowflake;
+		/**
+		 * The ID of the user whose stream to display for this invite, required if `target_type`
+		 * is 1, the user must be streaming in the channel.
+		 */
+		target_user_id?: Snowflake;
 
-	/**
-	 * The ID of the embedded application to open for this invite, required if `target_type` is 2,
-	 * the application must have the `EMBEDDED` flag.
-	 */
-	target_application_id?: Snowflake;
+		/**
+		 * The ID of the embedded application to open for this invite, required if `target_type`
+		 * is 2, the application must have the `EMBEDDED` flag.
+		 */
+		target_application_id?: Snowflake;
+	};
+
+	response: Invite;
 }
+
+/**
+ * Delete a channel permission overwrite for a user or role in a channel. Requires the
+ * `MANAGE_ROLES` permission. Only usable for guild channels.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-channel-permission) `/channels/{channel.id}/permissions/{overwrite.id}`
+ */
+export type DeleteChannelPermission = { response: never };
 
 /**
  * Follow a News Channel to send messages to a target channel. Requires the `MANAGE_WEBHOOKS`
  * permission in the target channel.
  *
- * @endpoint [POST] `/channels/{channel.id}/followers`
- *
- * @returns A [followed channel][1] object.
- *
- * [POST]: https://discord.com/developers/docs/resources/channel#follow-news-channel
- * [1]: https://discord.com/developers/docs/resources/channel#followed-channel-object
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#follow-news-channel) `/channels/{channel.id}/followers`
  */
 export interface FollowNewsChannel {
-	/**
-	 * ID of target channel.
-	 */
-	webhook_channel_id: Snowflake;
+	body: {
+		/**
+		 * ID of target channel.
+		 */
+		webhook_channel_id: Snowflake;
+	};
+
+	response: FollowedChannel;
 }
+
+/**
+ * Post a typing indicator for the specified channel.
+ *
+ * @remarks
+ * Generally bots should **not** implement this route. However, if a bot is responding to a command
+ * and expects the computation to take a few seconds, this endpoint may be called to let the user
+ * know that the bot is processing their message.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/resources/channel#trigger-typing-indicator) `/channels/{channel.id}/typing`
+ */
+export type TriggerTypingIndicator = { response: never };
+
+/**
+ * Returns all pinned messages in the channel.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/channel#get-pinned-messages) `/channels/{channel.id}/pins`
+ */
+export type GetPinnedMessages = { response: Message[] };
+
+/**
+ * Pin a message in a channel. Requires the `MANAGE_MESSAGES` permission.
+ *
+ * @warning
+ * The max pinned messages is 50.
+ *
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/channel#add-pinned-channel-message) `/channels/{channel.id}/pins/{message.id}`
+ */
+export type AddPinnedChannelMessage = { response: never };
+
+/**
+ * Delete a pinned message in a channel. Requires the `MANAGE_MESSAGES` permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message) `/channels/{channel.id}/pins/{message.id}`
+ */
+export type DeletePinnedChannelMessage = { response: never };
 
 /**
  * Adds a recipient to a Group DM using their access token.
  *
- * @endpoint [PUT] `/channels/{channel.id}/recipients/{user.id}`
- *
- * [PUT]: https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/channel#group-dm-add-recipient) `/channels/{channel.id}/recipients/{user.id}`
  */
 export interface GroupDMAddRecipient {
-	/**
-	 * Access token of a user that has granted your app the `gdm.join` scope.
-	 */
-	access_token: string;
+	body: {
+		/**
+		 * Access token of a user that has granted your app the `gdm.join` scope.
+		 */
+		access_token: string;
 
-	/**
-	 * Nickname of the user being added.
-	 */
-	nick: string;
+		/**
+		 * Nickname of the user being added.
+		 */
+		nick: string;
+	};
+
+	response: never;
 }
+
+/**
+ * Removes a recipient from a Group DM.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/channel#group-dm-delete-recipient) `/channels/{channel.id}/recipients/{user.id}`
+ */
+export type GroupDMRemoveRecipient = { response: never };
 
 // !SECTION

--- a/src/resources/Discovery.ts
+++ b/src/resources/Discovery.ts
@@ -83,23 +83,27 @@ export interface DiscoverySubcategory {
 	category_id: number;
 }
 
-export interface ValidDiscoverySearchTerm {
-	/**
-	 * Whether the provided term is valid.
-	 */
-	valid: boolean;
-}
-
 // SECTION Endpoints
 
 /**
  * @endpoint GET `/discovery/valid-term`
  */
 export interface ValidateDiscoverySearchTerm {
+	body: {
+		/**
+		 * The search term to check.
+		 */
+		term: string;
+	};
+
+	response: ValidDiscoverySearchTerm;
+}
+
+export interface ValidDiscoverySearchTerm {
 	/**
-	 * The search term to check.
+	 * Whether the provided term is valid.
 	 */
-	term: string;
+	valid: boolean;
 }
 
 // !SECTION

--- a/src/resources/Emoji.ts
+++ b/src/resources/Emoji.ts
@@ -65,6 +65,20 @@ export interface Emoji extends PartialEmoji {
 // SECTION Endpoints
 
 /**
+ * Returns a list of emoji objects for the given guild.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/emoji#list-guild-emojis) `/guilds/{guild.id}/emojis`
+ */
+export type ListGuildEmojis = { response: Emoji[] };
+
+/**
+ * Returns an emoji object for the given guild and emoji IDs.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/emoji#get-guild-emojis) `/guilds/{guild.id}/emojis/{emoji.id}`
+ */
+export type GetGuildEmoji = { response: Emoji };
+
+/**
  * Create a new emoji for the guild. Requires the `MANAGE_EMOJIS` permission.
  *
  * @warning
@@ -72,54 +86,61 @@ export interface Emoji extends PartialEmoji {
  * larger than this limit will fail and return `400 BAD REQUEST` and an error message, but not a
  * JSON status code.
  *
- * @endpoint [POST] `/guilds/{guild.id}/emojis`
- *
- * @returns The new [emoji][1] object on success.
- * @fires A [Guild Emojis Update][2] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/emoji#create-guild-emoji
- * [1]: https://discord.com/developers/docs/resources/emoji#emoji-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-emojis-update
+ * @endpoint [POST](https://discord.com/developers/docs/resources/emoji#create-guild-emoji) `/guilds/{guild.id}/emojis`
  */
-export interface CreateEmoji {
-	/**
-	 * Name of the emoji.
-	 */
-	name: string;
+export interface CreateGuildEmoji {
+	body: {
+		/**
+		 * Name of the emoji.
+		 */
+		name: string;
+
+		/**
+		 * The 128x128 emoji image.
+		 */
+		image: string;
+
+		/**
+		 * Roles for which this emoji will be whitelisted.
+		 */
+		roles: Snowflake[];
+	};
 
 	/**
-	 * The 128x128 emoji image.
+	 * The new emoji object.
 	 */
-	image: string;
-
-	/**
-	 * Roles for which this emoji will be whitelisted.
-	 */
-	roles: Snowflake[];
+	response: Emoji;
 }
 
 /**
  * Modify the given emoji. Requires the `MANAGE_EMOJIS` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/emojis/{emoji.id}`
- *
- * @returns The updated [emoji][1] object on success.
- * @fires A [Guild Emojis Update][2] Gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/emoji#modify-guild-emoji
- * [1]: https://discord.com/developers/docs/resources/emoji#emoji-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-emojis-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/emoji#modify-guild-emoji) `/guilds/{guild.id}/emojis/{emoji.id}`
  */
-export interface ModifyEmoji {
-	/**
-	 * Name of the emoji.
-	 */
-	name?: string;
+export interface ModifyGuildEmoji {
+	body: {
+		/**
+		 * Name of the emoji.
+		 */
+		name?: string;
+
+		/**
+		 * Roles for which this emoji will be whitelisted.
+		 */
+		roles?: Nullable<Snowflake[]>;
+	};
 
 	/**
-	 * Roles for which this emoji will be whitelisted.
+	 * The updated emoji object.
 	 */
-	roles?: Nullable<Snowflake[]>;
+	response: Emoji;
 }
+
+/**
+ * Delete the given emoji. Requires the `MANAGE_EMOJIS` permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/emoji#delete-guild-emoji) `/guilds/{guild.id}/emojis/{emoji.id}`
+ */
+export type DeleteGuildEmoji = { response: never };
 
 // !SECTION

--- a/src/resources/Guild.ts
+++ b/src/resources/Guild.ts
@@ -14,6 +14,8 @@ import type {
 	VoiceRegion,
 	VoiceState
 } from '../';
+import { DiscoveryMetadata } from './Discovery';
+import { InviteMetadata, PartialInvite } from './Invite';
 
 // ANCHOR Partial Guild
 
@@ -1054,456 +1056,464 @@ export enum ScreeningFieldType {
  * @warning
  * This endpoint can be used only by bots in less than 10 guilds.
  *
- * @endpoint [POST] `/guilds`
- *
- * @returns A [guild][1] object on success.
- * @fires A [Guild Create][2] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/guild#create-guild
- * [1]: https://discord.com/developers/docs/resources/guild#guild-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#create-guild) `/guilds`
  */
 export interface CreateGuild {
-	/**
-	 * Name of the guild (2-100 characters).
-	 */
-	name: string;
+	body: {
+		/**
+		 * Name of the guild (2-100 characters).
+		 */
+		name: string;
 
-	/**
-	 * [Voice region][1] ID.
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/voice#voice-region-object
-	 */
-	region?: string;
+		/**
+		 * Voice region ID.
+		 */
+		region?: string;
 
-	/**
-	 * Base64 128x128 image for the guild icon.
-	 */
-	icon?: string;
+		/**
+		 * Base64 128x128 image for the guild icon.
+		 */
+		icon?: string;
 
-	/**
-	 * [Verification level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-verification-level
-	 */
-	verification_level?: number | VerificationLevel;
+		/**
+		 * Verification level.
+		 */
+		verification_level?: VerificationLevel;
 
-	/**
-	 * Default [message notifications level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
-	 */
-	default_message_notifications?: number | NotificationLevel;
+		/**
+		 * Default message notifications level.
+		 */
+		default_message_notifications?: NotificationLevel;
 
-	/**
-	 * [Explicit content filter level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
-	 */
-	explicit_content_filter?: number | ExplicitFilterLevel;
+		/**
+		 * Explicit content filter level.
+		 */
+		explicit_content_filter?: ExplicitFilterLevel;
 
-	/**
-	 * New guild roles.
-	 *
-	 * @remarks
-	 * When using the `roles` parameter:
-	 * - The first member of the array is used to change properties of the guild's `@everyone` role.
-	 *   If you are trying to bootstrap a guild with additional roles, keep this in mind.
-	 * - The required `id` field within each role object is an integer placeholder, and will be
-	 *   replaced by the API upon consumption. Its purpose is to allow you to overwrite a role's
-	 *   permissions in a channel when also passing in channels with the channels array.
-	 */
-	roles?: Role[];
+		/**
+		 * New guild roles.
+		 *
+		 * @remarks
+		 * When using the `roles` parameter:
+		 * - The first member of the array is used to change properties of the guild's `@everyone`
+		 * 	 role. If you are trying to bootstrap a guild with additional roles, keep this in mind.
+		 * - The required `id` field within each role object is an integer placeholder, and will be
+		 *   replaced by the API upon consumption. Its purpose is to allow you to overwrite a role's
+		 *   permissions in a channel when also passing in channels with the channels array.
+		 */
+		roles?: Role[];
 
-	/**
-	 * New guild's channels.
-	 *
-	 * @remarks
-	 * When using the `channels` parameter:
-	 * - The `position` field is ignored, and none of the default channels are created.
-	 * - The `id` field within each channel object may be set to an integer placeholder, and will
-	 *   be replaced by the API upon consumption. Its purpose is to allow you to create
-	 *   `GUILD_CATEGORY` channels by setting the `parent_id` field on any children to the
-	 *   category's `id` field. Category channels must be listed before any children.
-	 */
-	channels?: PartialChannel;
+		/**
+		 * New guild's channels.
+		 *
+		 * @remarks
+		 * When using the `channels` parameter:
+		 * - The `position` field is ignored, and none of the default channels are created.
+		 * - The `id` field within each channel object may be set to an integer placeholder, and
+		 * 	 will be replaced by the API upon consumption. Its purpose is to allow you to create
+		 *   `GUILD_CATEGORY` channels by setting the `parent_id` field on any children to the
+		 *   category's `id` field. Category channels must be listed before any children.
+		 */
+		channels?: PartialChannel;
 
-	/**
-	 * ID for AFK channel.
-	 */
-	afk_channel_id?: Snowflake;
+		/**
+		 * ID for AFK channel.
+		 */
+		afk_channel_id?: Snowflake;
 
-	/**
-	 * AFK timeout in seconds.
-	 */
-	afk_timeout?: number;
+		/**
+		 * AFK timeout in seconds.
+		 */
+		afk_timeout?: number;
 
-	/**
-	 * The ID of the channel where guild notices such as welcome messages and boost events are
-	 * posted.
-	 */
-	system_channel_id?: Snowflake;
+		/**
+		 * The ID of the channel where guild notices such as welcome messages and boost events are
+		 * posted.
+		 */
+		system_channel_id?: Snowflake;
 
-	/**
-	 * [System channel flags][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
-	 */
-	system_channel_flags?: SystemChannelFlags;
+		/**
+		 * System channel flags.
+		 */
+		system_channel_flags?: SystemChannelFlags;
+	};
+
+	response: Guild;
 }
 
 /**
- * @remarks
- * If `with_counts` is set to true, this endpoint will also return `approximate_member_count` and
+ * Returns the guild object for the given ID.
+ *
+ * If `with_counts` is set to `true`, this endpoint will also return `approximate_member_count` and
  * `approximate_presence_count` for the guild.
  *
- * @endpoint [GET] `/guilds/{guild.id}`
- *
- * @returns The [guild][1] object for the given ID.
- *
- * [GET]: https://discord.com/developers/docs/resources/guild#create-guild
- * [1]: https://discord.com/developers/docs/resources/guild#guild-object
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild) `/guilds/{guild.id}`
  */
 export interface GetGuild {
-	/**
-	 * When `true`, will return approximate member and presence counts for the guild.
-	 *
-	 * @defaultValue false
-	 */
-	with_counts?: boolean;
+	query: {
+		/**
+		 * When `true`, will return approximate member and presence counts for the guild.
+		 *
+		 * @defaultValue false
+		 */
+		with_counts?: boolean;
+	};
+
+	response: Guild;
 }
+
+/**
+ * Returns the guild preview object for the given ID.
+ *
+ * If the user is not in the guild, then the guild must be Discoverable.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-preview) `/guilds/{guild.id}/preview`
+ */
+export type GetGuildPreview = { response: GuildPreview };
 
 /**
  * Modify a guild's settings. Requires the `MANAGE_GUILD` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}`
- *
- * @returns The updated [guild][1] object on success.
- * @fires A [Guild Update][2] Gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-guild
- * [1]: https://discord.com/developers/docs/resources/guild#guild-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild) `/guilds/{guild.id}`
  */
 export interface ModifyGuild {
-	/**
-	 * Guild name.
-	 */
-	name?: string;
+	body: {
+		/**
+		 * Guild name.
+		 */
+		name?: string;
+
+		/**
+		 * Guild voice region ID.
+		 */
+		region?: Nullable<string>;
+
+		/**
+		 * Verification level.
+		 */
+		verification_level?: Nullable<VerificationLevel>;
+
+		/**
+		 * Default message notifications level.
+		 */
+		default_message_notifications?: Nullable<NotificationLevel>;
+
+		/**
+		 * Explicit content filter level.
+		 */
+		explicit_content_filter?: Nullable<ExplicitFilterLevel>;
+
+		/**
+		 * ID for AFK channel.
+		 */
+		afk_channel_id?: Nullable<Snowflake>;
+
+		/**
+		 * AFK timeout in seconds.
+		 */
+		afk_timeout?: Nullable<number>;
+
+		/**
+		 * Base64 1024x1024 png/jpeg/gif image for the guild icon (can be animated gif when the
+		 * server has `ANIMATED_ICON` feature).
+		 */
+		icon?: Nullable<string>;
+
+		/**
+		 * User ID to transfer guild ownership to (must be owner).
+		 */
+		owner_id?: Snowflake;
+
+		/**
+		 * Base64 16:9 png/jpeg image for the guild splash (when the server has `INVITE_SPLASH`
+		 * feature).
+		 */
+		splash?: Nullable<string>;
+
+		/**
+		 * Base64 16:9 png/jpeg image for the guild banner (when the server has `BANNER` feature).
+		 */
+		banner?: Nullable<string>;
+
+		/**
+		 * The ID of the channel where guild notices such as welcome messages and boost events are
+		 * posted.
+		 */
+		system_channel_id?: Nullable<Snowflake>;
+
+		/**
+		 * System channel flags.
+		 */
+		system_channel_flags?: SystemChannelFlags;
+
+		/**
+		 * The ID of the channel where Community guilds display rules and/or guidelines.
+		 */
+		rules_channel_id?: Nullable<Snowflake>;
+
+		/**
+		 * The ID of the channel where admins and moderators of Community guilds receive notices
+		 * from Discord.
+		 */
+		public_updates_channel_id?: Nullable<Snowflake>;
+
+		/**
+		 * The preferred locale of a Community guild used in server discovery and notices from
+		 * Discord
+		 *
+		 * @defaultValue en-US
+		 */
+		preferred_locale?: Nullable<string>;
+
+		/**
+		 * Enabled guild features.
+		 */
+		features?: GuildFeatures[];
+
+		/**
+		 * The description for the guild, if the guild is discoverable.
+		 */
+		description?: string;
+	};
 
 	/**
-	 * Guild [voice region][1] ID.
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/voice#voice-region-object
+	 * The updated guild object.
 	 */
-	region?: Nullable<string>;
-
-	/**
-	 * [Verification level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-verification-level
-	 */
-	verification_level?: Nullable<number | VerificationLevel>;
-
-	/**
-	 * Default [message notifications level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level
-	 */
-	default_message_notifications?: Nullable<number | NotificationLevel>;
-
-	/**
-	 * [Explicit content filter level][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level
-	 */
-	explicit_content_filter?: Nullable<number | ExplicitFilterLevel>;
-
-	/**
-	 * ID for AFK channel.
-	 */
-	afk_channel_id?: Nullable<Snowflake>;
-
-	/**
-	 * AFK timeout in seconds.
-	 */
-	afk_timeout?: Nullable<number>;
-
-	/**
-	 * Base64 1024x1024 png/jpeg/gif image for the guild icon (can be animated gif when the server
-	 * has `ANIMATED_ICON` feature).
-	 */
-	icon?: Nullable<string>;
-
-	/**
-	 * User ID to transfer guild ownership to (must be owner).
-	 */
-	owner_id?: Snowflake;
-
-	/**
-	 * Base64 16:9 png/jpeg image for the guild splash (when the server has `INVITE_SPLASH`
-	 * feature).
-	 */
-	splash?: Nullable<string>;
-
-	/**
-	 * Base64 16:9 png/jpeg image for the guild banner (when the server has `BANNER` feature).
-	 */
-	banner?: Nullable<string>;
-
-	/**
-	 * The ID of the channel where guild notices such as welcome messages and boost events are
-	 * posted.
-	 */
-	system_channel_id?: Nullable<Snowflake>;
-
-	/**
-	 * [System channel flags][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags
-	 */
-	system_channel_flags?: SystemChannelFlags;
-
-	/**
-	 * The ID of the channel where Community guilds display rules and/or guidelines.
-	 */
-	rules_channel_id?: Nullable<Snowflake>;
-
-	/**
-	 * The ID of the channel where admins and moderators of Community guilds receive notices from
-	 * Discord.
-	 */
-	public_updates_channel_id?: Nullable<Snowflake>;
-
-	/**
-	 * The preferred locale of a Community guild used in server discovery and notices from Discord
-	 *
-	 * @defaultValue en-US
-	 */
-	preferred_locale?: Nullable<string>;
-
-	/**
-	 * Enabled guild features.
-	 */
-	features?: GuildFeatures[];
-
-	/**
-	 * The description for the guild, if the guild is discoverable.
-	 */
-	description: string;
+	response: Guild;
 }
 
 /**
- * Create a new [channel][1] object for the guild. Requires the `MANAGE_CHANNELS` permission. If
- * setting permission overwrites, only permissions your bot has in the guild can be allowed/denied.
- * Setting `MANAGE_ROLES` permission in channels is only possible for guild administrators.
+ * Delete a guild permanently. User must be owner.
  *
- * @endpoint [POST] `/guilds/{guild.id}/channels`
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#delete-guild) `/guilds/{guild.id}`
+ */
+export type DeleteGuild = { response: never };
+
+/**
+ * Returns a list of guild channel objects.
  *
- * @returns The new [channel][1] object on success.
- * @fires A [Channel Create][2] Gateway event.
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-channels) `/guilds/{guild.id}/channels`
+ */
+export type GetGuildChannels = { response: Channel[] };
+
+/**
+ * Create a new channel object for the guild. Requires the `MANAGE_CHANNELS` permission.
  *
- * [POST]: https://discord.com/developers/docs/resources/guild#create-guild-channel
- * [1]: https://discord.com/developers/docs/resources/channel#channel-object
- * [2]: https://discord.com/developers/docs/topics/gateway#channel-create
+ * If setting permission overwrites, only permissions your bot has in the guild can be allowed/
+ * denied. Setting `MANAGE_ROLES` permission in channels is only possible for guild administrators.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#create-guild-channel) `/guilds/{guild.id}/channels`
  */
 export interface CreateGuildChannel {
-	/**
-	 * Channel name (2-100 characters).
-	 */
-	name: string;
+	body: {
+		/**
+		 * Channel name (2-100 characters).
+		 */
+		name: string;
+
+		/**
+		 * The type of channel.
+		 */
+		type?: ChannelType;
+
+		/**
+		 * Channel topic (0-1024 characters).
+		 */
+		topic?: string;
+
+		/**
+		 * The bitrate (in bits) of the voice channel (voice only).
+		 */
+		bitrate?: number;
+
+		/**
+		 * The user limit of the voice channel (voice only).
+		 */
+		user_limit?: number;
+
+		/**
+		 * Amount of seconds a user has to wait before sending another message (0-21600); bots, as
+		 * well as users with the permission `manage_messages` or `manage_channel`, are unaffected.
+		 */
+		rate_limit_per_user?: number;
+
+		/**
+		 * Sorting position of the channel.
+		 */
+		position?: number;
+
+		/**
+		 * The channel's permission overwrites.
+		 */
+		permission_overwrites?: Overwrite[];
+
+		/**
+		 * ID of the parent category for a channel.
+		 */
+		parent_id?: Snowflake;
+
+		/**
+		 * Whether the channel is NSFW.
+		 */
+		nsfw?: boolean;
+	};
 
 	/**
-	 * The [type of channel][1].
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/channel#channel-object-channel-types
+	 * The new channel object.
 	 */
-	type?: number | ChannelType;
-
-	/**
-	 * Channel topic (0-1024 characters).
-	 */
-	topic?: string;
-
-	/**
-	 * The bitrate (in bits) of the voice channel (voice only).
-	 */
-	bitrate?: number;
-
-	/**
-	 * The user limit of the voice channel (voice only).
-	 */
-	user_limit?: number;
-
-	/**
-	 * Amount of seconds a user has to wait before sending another message (0-21600); bots, as
-	 * well as users with the permission `manage_messages` or `manage_channel`, are unaffected.
-	 */
-	rate_limit_per_user?: number;
-
-	/**
-	 * Sorting position of the channel.
-	 */
-	position?: number;
-
-	/**
-	 * The channel's permission overwrites.
-	 */
-	permission_overwrites?: Overwrite[];
-
-	/**
-	 * ID of the parent category for a channel.
-	 */
-	parent_id?: Snowflake;
-
-	/**
-	 * Whether the channel is NSFW.
-	 */
-	nsfw?: boolean;
+	response: Channel;
 }
 
 /**
- * Modify the positions of a set of [channel][1] objects for the guild. Requires `MANAGE_CHANNELS`
+ * Modify the positions of a set of channel objects for the guild. Requires `MANAGE_CHANNELS`
  * permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/channels`
- *
- * @returns A `204` empty response on success.
- * @fires Multiple [Channel Update] Gateway events.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
- * [1]: https://discord.com/developers/docs/resources/channel#channel-object
- * [2]: https://discord.com/developers/docs/topics/gateway#channel-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions) `/guilds/{guild.id}/channels`
  */
 export interface ModifyGuildChannelPositions {
-	/**
-	 * Channel ID.
-	 */
-	id: Snowflake;
+	body: {
+		/**
+		 * Channel ID.
+		 */
+		id: Snowflake;
 
-	/**
-	 * Sorting position of the channel.
-	 */
-	position: Nullable<number>;
+		/**
+		 * Sorting position of the channel.
+		 */
+		position: Nullable<number>;
 
-	/**
-	 * Syncs the permission overwrites with the new parent, if moving to a new category.
-	 */
-	lock_permissions: Nullable<boolean>;
+		/**
+		 * Syncs the permission overwrites with the new parent, if moving to a new category.
+		 */
+		lock_permissions: Nullable<boolean>;
 
-	/**
-	 * The new parent ID for the channel that is moved.
-	 */
-	parent_id: Snowflake;
+		/**
+		 * The new parent ID for the channel that is moved.
+		 */
+		parent_id: Snowflake;
+	};
+
+	response: never;
 }
 
 /**
- * @endpoint [GET] `/guilds/{guild.id}/members`
+ * Returns a guild member object for the specified user.
  *
- * @returns A list of [guild member][1] objects that are members of the guild, sorted by their ID
- * in ascending order.
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-member) `/guilds/{guild.id}/members/{user.id}`
+ */
+export type GetGuildMember = { response: GuildMember };
+
+/**
+ * Returns a list of guild member objects that are members of the guild.
  *
- * [GET]: https://discord.com/developers/docs/resources/guild#list-guild-members
- * [1]: https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#list-guild-members) `/guilds/{guild.id}/members`
  */
 export interface ListGuildMembers {
-	/**
-	 * Max number of members to return (1-1000).
-	 *
-	 * @defaultValue 1
-	 */
-	limit?: RangeOf<1, 1000>;
+	query: {
+		/**
+		 * Max number of members to return (1-1000).
+		 *
+		 * @defaultValue 1
+		 */
+		limit?: RangeOf<1, 1000>;
+
+		/**
+		 * The highest user ID in the previous page.
+		 *
+		 * @defaultValue 0
+		 */
+		after?: Snowflake;
+	};
 
 	/**
-	 * The highest user ID in the previous page.
-	 *
-	 * @defaultValue 0
+	 * An array of guild members, sorted by their ID in ascending order.
 	 */
-	after?: Snowflake;
+	response: GuildMember[];
 }
 
 /**
  * @endpoint GET `/guilds/{guild.id}/members/search`
- *
- * @returns A list of [guild member][1] objects whose username or nickname starts with a provided
- * string.
- *
- * [1]: https://discord.com/developers/docs/resources/guild#guild-member-object
  */
 export interface SearchGuildMembers {
-	/**
-	 * Query string to match username(s) and nickname(s) against.
-	 */
-	query: string;
+	query: {
+		/**
+		 * Query string to match username(s) and nickname(s) against.
+		 */
+		query: string;
+
+		/**
+		 * Max numbers of members to return (1-1000).
+		 *
+		 * @defaultValue 1
+		 */
+		limit?: RangeOf<1, 1000>;
+	};
 
 	/**
-	 * Max numbers of members to return (1-1000).
-	 *
-	 * @defaultValue 1
+	 * An array of guild member objects whose username or nickname starts with a provided string.
 	 */
-	limit?: RangeOf<1, 1000>;
+	response: GuildMember[];
 }
 
 /**
  * Adds a user to the guild, provided you have a valid OAuth2 access token for the user with the
  * `guilds.join` scope.
  *
+ * @remarks
+ * For guilds with Membership Screening enabled, this endpoint will default to adding new members
+ * as `pending` in the guild member object. Members that are `pending` will have to complete
+ * membership screening before they become full members that can talk.
+ *
  * @info
  * The Authorization header must be a Bot token (belonging to the same application used for
  * authorization), and the bot must be a member of the guild with `CREATE_INSTANT_INVITE`
  * permission.
  *
- * @endpoint [PUT] `/guilds/{guild.id}/members/{user.id}`
- *
- * @returns A `201 CREATED` with the [guild member][1] as the body, or `204 NO CONTENT` if the user
- * is already a member of the guild
- *
- * @fires A [Guild Member Add][2] Gateway event.
- *
- * [PUT]: https://discord.com/developers/docs/resources/guild#add-guild-member
- * [1]: https://discord.com/developers/docs/resources/guild#guild-member-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-member-add
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/guild#add-guild-member) `/guilds/{guild.id}/members/{user.id}`
  */
 export interface AddGuildMember {
-	/**
-	 * An OAuth2 access token granted with the `guilds.join` to the bot's application for the user
-	 * you want to add to the guild.
-	 */
-	access_token: string;
+	body: {
+		/**
+		 * An OAuth2 access token granted with the `guilds.join` to the bot's application for the
+		 * user you want to add to the guild.
+		 */
+		access_token: string;
 
-	/**
-	 * Value to set users nickname to.
-	 *
-	 * @permission `MANAGE_NICKNAMES`
-	 */
-	nick?: string;
+		/**
+		 * Value to set users nickname to.
+		 *
+		 * @permission `MANAGE_NICKNAMES`
+		 */
+		nick?: string;
 
-	/**
-	 * Array of role ids the member is assigned.
-	 *
-	 * @permission `MANAGE_ROLES`
-	 */
-	roles?: Snowflake[];
+		/**
+		 * Array of role ids the member is assigned.
+		 *
+		 * @permission `MANAGE_ROLES`
+		 */
+		roles?: Snowflake[];
 
-	/**
-	 * Whether the user is muted in voice channels.
-	 *
-	 * @permission `MUTE_MEMBERS`
-	 */
-	mute?: boolean;
+		/**
+		 * Whether the user is muted in voice channels.
+		 *
+		 * @permission `MUTE_MEMBERS`
+		 */
+		mute?: boolean;
 
-	/**
-	 * Whether the user is deafened in voice channels.
-	 *
-	 * @permission `DEAFEN_MEMBERS`
-	 */
-	deaf?: boolean;
+		/**
+		 * Whether the user is deafened in voice channels.
+		 *
+		 * @permission `DEAFEN_MEMBERS`
+		 */
+		deaf?: boolean;
+	};
+
+	response: GuildMember | never;
 }
 
 /**
  * Modify attributes of a [guild member][1].
  *
- * @remarks
  * If the `channel_id` is set to `null`, this will force the target user to be disconnected from
  * voice.
  *
@@ -1511,209 +1521,262 @@ export interface AddGuildMember {
  * When moving members to channels, the API user *must* have permissions to both connect to the
  * channel and have the `MOVE_MEMBERS` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/members/{user.id}`
- *
- * @returns A `200 OK` with the [guild member][1] as the body.
- * @fires A [Guild Member Update][2] Gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-guild-member
- * [1]: https://discord.com/developers/docs/resources/guild#guild-member-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-member-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-member) `/guilds/{guild.id}/members/{user.id}`
  */
 export interface ModifyGuildMember {
-	/**
-	 * Value to set users nickname to.
-	 *
-	 * @permission `MANAGE_NICKNAMES`
-	 */
-	nick?: Nullable<string>;
+	body: {
+		/**
+		 * Value to set users nickname to.
+		 *
+		 * @permission `MANAGE_NICKNAMES`
+		 */
+		nick?: Nullable<string>;
 
-	/**
-	 * Array of role IDs the member is assigned.
-	 *
-	 * @permission `MANAGE_ROLES`
-	 */
-	roles?: Nullable<Snowflake[]>;
+		/**
+		 * Array of role IDs the member is assigned.
+		 *
+		 * @permission `MANAGE_ROLES`
+		 */
+		roles?: Nullable<Snowflake[]>;
 
-	/**
-	 * Whether the user is muted in voice channels.
-	 *
-	 * @permission `MUTE_MEMBERS`
-	 */
-	mute?: Nullable<boolean>;
+		/**
+		 * Whether the user is muted in voice channels.
+		 *
+		 * @permission `MUTE_MEMBERS`
+		 */
+		mute?: Nullable<boolean>;
 
-	/**
-	 * Whether the user is deafened in voice channels.
-	 *
-	 * @permission `DEAFEN_MEMBERS`
-	 */
-	deaf?: Nullable<boolean>;
+		/**
+		 * Whether the user is deafened in voice channels.
+		 *
+		 * @permission `DEAFEN_MEMBERS`
+		 */
+		deaf?: Nullable<boolean>;
 
-	/**
-	 * ID of channel to move user to (if they are connected to voice).
-	 *
-	 * @permission `MOVE_MEMBERS`
-	 */
-	channel_id?: Nullable<Snowflake>;
+		/**
+		 * ID of channel to move user to (if they are connected to voice).
+		 *
+		 * @permission `MOVE_MEMBERS`
+		 */
+		channel_id?: Nullable<Snowflake>;
+	};
+
+	response: GuildMember;
 }
 
 /**
  * Modifies the nickname of the current user in a guild.
  *
- * @endpoint [PATCH]() `/guilds/{guild.id}/members/@me`
- *
- * @returns A `200` with the nickname on success.
- * @fires A [Guild Member Update][1] Gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-current-user-nick
- * [1]: https://discord.com/developers/docs/topics/gateway#guild-member-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-current-user-nick) `/guilds/{guild.id}/members/@me`
  */
 export interface ModifyCurrentUserNick {
+	body: {
+		/**
+		 * Value to set users nickname to.
+		 *
+		 * @permission `CHANGE_NICKNAME`
+		 */
+		nick?: Nullable<string>;
+	};
+
 	/**
-	 * Value to set users nickname to.
-	 *
-	 * @permission `CHANGE_NICKNAME`
+	 * The nickname.
 	 */
-	nick?: Nullable<string>;
+	response: string;
 }
+
+/**
+ * Adds a role to a guild member. Requires the `MANAGE_ROLES` permission.
+ *
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/guild#add-guild-member-role) `/guilds/{guild.id}/members/{user.id}/roles/{role.id}`
+ */
+export type AddGuildMemberRole = { response: never };
+
+/**
+ * Removes a role from a guild member. Requires the `MANAGE_ROLES` permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#remove-guild-member-role) `/guilds/{guild.id}/members/{user.id}/roles/{role.id}`
+ */
+export type RemoveGuildMemberRole = { response: never };
+
+/**
+ * Remove a member from a guild. Requires `KICK_MEMBERS` permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#remove-guild-member) `/guilds/{guild.id}/members/{user.id}`
+ */
+export type RemoveGuildMember = { response: never };
+
+/**
+ * Returns a list of ban objects for the users banned from this guild. Requires the `BAN_MEMBERS`
+ * permission.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-bans) `/guilds/{guild.id}/bans`
+ */
+export type GetGuildBans = GuildBan[];
+
+/**
+ * Returns a ban object for the given user or a `404 NOT FOUND` if the ban cannot be found. Requires
+ * the `BAN_MEMBERS` permission.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-ban) `/guilds/{guild.id}/bans/{user.id}`
+ */
+export type GetGuildBan = GuildBan | never;
 
 /**
  * Create a guild ban, and optionally delete previous messages sent by the banned user. Requires
  * the `BAN_MEMBERS` permission.
  *
- * @endpoint [PUT] `/guilds/{guild.id}/bans/{user.id}`
- *
- * @returns A `204` empty response on success.
- * @fires A [Guild Ban Add][1] Gateway event.
- *
- * [PUT]: https://discord.com/developers/docs/resources/guild#create-guild-ban
- * [1]: https://discord.com/developers/docs/topics/gateway#guild-ban-add
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/guild#create-guild-ban) `/guilds/{guild.id}/bans/{user.id}`
  */
 export interface CreateGuildBan {
-	/**
-	 * Number of days to delete messages for (0-7).
-	 */
-	delete_messages_days?: RangeOf<0, 7>;
+	body: {
+		/**
+		 * Number of days to delete messages for (0-7).
+		 */
+		delete_messages_days?: RangeOf<0, 7>;
 
-	/**
-	 * Reason for the ban.
-	 */
-	reason?: string;
+		/**
+		 * Reason for the ban.
+		 */
+		reason?: string;
+	};
+
+	response: never;
 }
 
 /**
- * Create a new [role][1] for the guild. Requires the `MANAGE_ROLES` permission.
+ * Remove the ban for a user. Requires the `BAN_MEMBERS` permissions.
  *
- * @endpoint [POST] `/guilds/{guild.id}/roles`
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#remove-guild-ban) `/guilds/{guild.id}/bans/{user.id}`
+ */
+export type RemoveGuildBan = { response: never };
+
+/**
+ * Returns a list of role objects for the guild.
  *
- * @returns The new [role][1] object on success.
- * @fires A [Guild Role Create][2] Gateway event.
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-roles) `/guilds/{guild.id}/roles`
+ */
+export type GetGuildRoles = { response: Role[] };
+
+/**
+ * Create a new role for the guild. Requires the `MANAGE_ROLES` permission.
  *
- * [POST]: https://discord.com/developers/docs/resources/guild#create-guild-role
- * [1]: https://discord.com/developers/docs/topics/permissions#role-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-role-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#create-guild-role) `/guilds/{guild.id}/roles`
  */
 export interface CreateGuildRole {
-	/**
-	 * Name of the role.
-	 *
-	 * @defaultValue new role
-	 */
-	name?: string;
+	body: {
+		/**
+		 * Name of the role.
+		 *
+		 * @defaultValue new role
+		 */
+		name?: string;
+
+		/**
+		 * Bitwise value of the enabled/disabled permissions.
+		 *
+		 * @defaultValue `@everyone` permissions in guild
+		 */
+		permissions?: string;
+
+		/**
+		 * RGB color value.
+		 *
+		 * @defaultValue 0
+		 */
+		color?: number;
+
+		/**
+		 * Whether the role should be displayed separately in the sidebar.
+		 *
+		 * @defaultValue false
+		 */
+		hoist?: boolean;
+
+		/**
+		 * Whether the role should be mentionable.
+		 *
+		 * @defaultValue false
+		 */
+		mentionable?: boolean;
+	};
 
 	/**
-	 * Bitwise value of the enabled/disabled permissions.
-	 *
-	 * @defaultValue `@everyone` permissions in guild
+	 * The new role.
 	 */
-	permissions?: string;
-
-	/**
-	 * RGB color value.
-	 *
-	 * @defaultValue 0
-	 */
-	color?: number;
-
-	/**
-	 * Whether the role should be displayed separately in the sidebar.
-	 *
-	 * @defaultValue false
-	 */
-	hoist?: boolean;
-
-	/**
-	 * Whether the role should be mentionable.
-	 *
-	 * @defaultValue false
-	 */
-	mentionable?: boolean;
+	response: Role;
 }
 
 /**
- * Modify the positions of a set of [role][1] objects for the guild. Requires the `MANAGE_ROLES`
+ * Modify the positions of a set of role objects for the guild. Requires the `MANAGE_ROLES`
  * permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/roles`
- *
- * @returns A list of all of the guild's [role][1] objects on success, sorted by their ID in
- * ascending order.
- * @fires Multiple [Guild Role Update][2] Gateway events.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
- * [1]: https://discord.com/developers/docs/topics/permissions#role-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-role-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-role-positions) `/guilds/{guild.id}/roles`
  */
 export interface ModifyGuildRolePositions {
-	/**
-	 * Role.
-	 */
-	id: Snowflake;
+	body: {
+		/**
+		 * Role.
+		 */
+		id: Snowflake;
+
+		/**
+		 * Sorting position of the role.
+		 */
+		position?: Nullable<number>;
+	}[];
 
 	/**
-	 * Sorting position of the role.
+	 * A list of all of the guild's role objects on success, sorted by their ID in ascending order.
 	 */
-	position?: Nullable<number>;
+	response: Role[];
 }
 
 /**
  * Modify a guild role. Requires the `MANAGE_ROLES` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/roles/{role.id}`
- *
- * @returns The updated [role][1] on success.
- * @fires A [Guild Role Update][2] Gateway event.
- *
- * [PATCh]: https://discord.com/developers/docs/resources/guild#modify-guild-role
- * [1]: https://discord.com/developers/docs/topics/permissions#role-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-role-update
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-role) `/guilds/{guild.id}/roles/{role.id}`
  */
 export interface ModifyGuildRole {
-	/**
-	 * Name of the role.
-	 */
-	name?: Nullable<string>;
+	body: {
+		/**
+		 * Name of the role.
+		 */
+		name?: Nullable<string>;
+
+		/**
+		 * Bitwise value of the enabled/disabled permissions.
+		 */
+		permissions?: Nullable<string>;
+
+		/**
+		 * RGB color value.
+		 */
+		color?: Nullable<number>;
+
+		/**
+		 * Whether the role should be displayed separately in the sidebar.
+		 */
+		hoist?: Nullable<boolean>;
+
+		/**
+		 * Whether the role should be mentionable.
+		 */
+		mentionable?: Nullable<boolean>;
+	};
 
 	/**
-	 * Bitwise value of the enabled/disabled permissions.
+	 * The updated role.
 	 */
-	permissions?: Nullable<string>;
-
-	/**
-	 * RGB color value.
-	 */
-	color?: Nullable<number>;
-
-	/**
-	 * Whether the role should be displayed separately in the sidebar.
-	 */
-	hoist?: Nullable<boolean>;
-
-	/**
-	 * Whether the role should be mentionable.
-	 */
-	mentionable?: Nullable<boolean>;
+	response: Role;
 }
+
+/**
+ * Delete a guild role. Requires the `MANAGE_ROLES` permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#delete-guild-role) `/guilds/{guild.id}/roles/{role.id}`
+ */
+export type DeleteGuildRole = { response: never };
 
 /**
  * Requires the `KICK_MEMBERS` permission.
@@ -1723,25 +1786,29 @@ export interface ModifyGuildRole {
  * your prune by providing the `include_roles` parameter. Any inactive user that has a subset of the
  * provided role(s) will be counted in the prune and users with additional roles will not.
  *
- * @endpoint [GET] `/guilds/{guild.id}/prune`
- *
- * @returns An object with one `pruned` key indicating the number of members that would be removed
- * in a prune operation.
- *
- * [GET]: https://discord.com/developers/docs/resources/guild#get-guild-prune-count
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-prune-count) `/guilds/{guild.id}/prune`
  */
 export interface GetGuildPruneCount {
-	/**
-	 * Number of days to count prune for (1-30).
-	 *
-	 * @defaultValue 7
-	 */
-	days?: RangeOf<1, 30>;
+	query: {
+		/**
+		 * Number of days to count prune for (1-30).
+		 *
+		 * @defaultValue 7
+		 */
+		days?: RangeOf<1, 30>;
 
-	/**
-	 * Role(s) to include.
-	 */
-	include_roles?: Snowflake[];
+		/**
+		 * Role(s) to include.
+		 */
+		include_roles?: Snowflake[];
+	};
+
+	response: {
+		/**
+		 * The number of members that would be removed in a prune operation.
+		 */
+		pruned: number;
+	};
 }
 
 /**
@@ -1755,105 +1822,176 @@ export interface GetGuildPruneCount {
  * your prune by providing the `include_roles` parameter. Any inactive user that has a subset of
  * the provided role(s) will be counted in the prune and users with additional roles will not.
  *
- * @endpoint [POST] `/guilds/{guild.id}/prune`
- *
- * @returns An object with one `pruned` key indicating the number of members that were removed in
- * the prune operation.
- * @fires Multiple [Guild Member Remove][1] Gateway events.
- *
- * [POST]: https://discord.com/developers/docs/resources/guild#begin-guild-prune
- * [1]: https://discord.com/developers/docs/topics/gateway#guild-member-remove
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#begin-guild-prune)`/guilds/{guild.id}/prune`
  */
 export interface BeginGuildPrune {
-	/**
-	 * Number of days to prune (1-30).
-	 *
-	 * @defaultValue 7
-	 */
-	days?: RangeOf<1, 30>;
+	body: {
+		/**
+		 * Number of days to prune (1-30).
+		 *
+		 * @defaultValue 7
+		 */
+		days?: RangeOf<1, 30>;
 
-	/**
-	 * Whether `pruned` is returned, discouraged for large guilds.
-	 *
-	 * @defaultValue true
-	 */
-	compute_prune_count?: boolean;
+		/**
+		 * Whether `pruned` is returned, discouraged for large guilds.
+		 *
+		 * @defaultValue true
+		 */
+		compute_prune_count?: boolean;
 
-	/**
-	 * Role(s) to include.
-	 */
-	include_roles?: Snowflake[];
+		/**
+		 * Role(s) to include.
+		 */
+		include_roles?: Snowflake[];
+	};
+
+	response: GetGuildPruneCount['response'];
 }
 
 /**
- * Attach an [integration][1] object from the current user to the guild. Requires the `MANAGE_GUILD`
- * permission.
+ * Returns a list of voice region objects for the guild.
  *
- * @endpoint [POST] `/guilds/{guild.id}/integrations`
+ * Unlike the similar `/voice` route, this returns VIP servers when the guild is VIP-enabled.
  *
- * @returns A `204` empty response on success.
- * @fires A [Guild Integrations Update][2] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/guild#create-guild-integration
- * [1]: https://discord.com/developers/docs/resources/guild#integration-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-integrations-update
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-voice-regions) `/guilds/{guild.id}/regions`
  */
-export interface CreateGuildIntegration {
-	/**
-	 * 	The integration type.
-	 */
-	type: IntegrationType;
-
-	/**
-	 * The integration ID.
-	 */
-	id: Snowflake;
-}
+export type GetGuildVoiceRegions = { response: VoiceRegion[] };
 
 /**
- * Modify the behavior and settings of an [integration][1] object for the guild. Requires the
+ * Returns a list of invite objects (with invite metadata) for the guild. Requires the
  * `MANAGE_GUILD` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/integrations/{integration.id}`
- *
- * @returns A `204` empty response on success.
- * @fires A [Guild Integrations Update][2] Gateway event.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/guild#modify-guild-integration
- * [1]: https://discord.com/developers/docs/resources/guild#integration-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-integrations-update
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-invites) `/guilds/{guild.id}/invites`
  */
-export interface EditIntegration {
-	/**
-	 * The behavior when an integration subscription lapses.
-	 */
-	expire_behavior?: Nullable<number>;
+export type GetGuildInvites = { response: InviteMetadata[] };
 
-	/**
-	 * Period (in days) where the integration will ignore lapsed subscriptions.
-	 */
-	expire_grace_period?: Nullable<number>;
+/**
+ * Returns a list of integration objects for the guild. Requires the `MANAGE_GUILD` permission.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-integrations) `/guilds/{guild.id}/integrations`
+ */
+export type GetGuildIntegrations = { response: Integration[] };
 
-	/**
-	 * Whether emoticons should be synced for this integration (Twitch only currently).
-	 */
-	enable_emoticons?: Nullable<boolean>;
+/**
+ * Attach an integration object from the current user to the guild. Requires the `MANAGE_GUILD`
+ * permission.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#create-guild-integration) `/guilds/{guild.id}/integrations`
+ */
+export interface CreateGuildIntegration {
+	body: {
+		/**
+		 * 	The integration type.
+		 */
+		type: IntegrationType;
+
+		/**
+		 * The integration ID.
+		 */
+		id: Snowflake;
+	};
+
+	response: never;
 }
 
 /**
- * @endpoint [GET] `/guilds/{guild.id}/widget.png`
+ * Modify the behavior and settings of an integration object for the guild. Requires the
+ * `MANAGE_GUILD` permission.
  *
- * @returns A PNG image widget for the guild.
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-integration) `/guilds/{guild.id}/integrations/{integration.id}`
+ */
+export interface ModifyGuildIntegration {
+	body: {
+		/**
+		 * The behavior when an integration subscription lapses.
+		 */
+		expire_behavior?: Nullable<number>;
+
+		/**
+		 * Period (in days) where the integration will ignore lapsed subscriptions.
+		 */
+		expire_grace_period?: Nullable<number>;
+
+		/**
+		 * Whether emoticons should be synced for this integration (Twitch only currently).
+		 */
+		enable_emoticons?: Nullable<boolean>;
+	};
+
+	response: never;
+}
+
+/**
+ * Delete the attached integration object for the guild. Requires the `MANAGE_GUILD` permission.
  *
- * [GET]: https://discord.com/developers/docs/resources/guild#get-guild-widget-image
+ * Deletes any associated webhooks and kicks the associated bot if there is one.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/guild#delete-guild-integration) `/guilds/{guild.id}/integrations/{integration.id}`
+ */
+export type DeleteGuildIntegration = { response: never };
+
+/**
+ * Sync an integration. Requires the `MANAGE_GUILD` permission.
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/resources/guild#sync-guild-integration) `/guilds/{guild.id}/integrations/{integration.id}/sync`
+ */
+export type SyncGuildIntegration = { response: never };
+
+/**
+ * Returns a guild widget object.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-widget-settings) `/guilds/{guild.id}/widget`
+ */
+export type GetGuildWidgetSettings = GuildWidget;
+
+/**
+ * Modify a guild widget object for the guild. Requires the `MANAGE_GUILD` permission.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/guild#modify-guild-widget) `/guilds/{guild.id}/widget`
+ */
+export interface ModifyGuildWidget {
+	body: Partial<GuildWidget>;
+
+	/**
+	 * The updated guild widget object.
+	 */
+	response: GuildWidget;
+}
+
+/**
+ * Returns the widget for the guild.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-widget) `/guilds/{guild.id}/widget.json`
+ */
+export type GetGuildWidget = { response: GuildWidget };
+
+/**
+ * Returns a partial invite object for guilds with that feature enabled. Requires the
+ * `MANAGE_GUILD` permission.
+ *
+ * `code` will be null if a vanity url for the guild is not set.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-vanity-url) `/guilds/{guild.id}/vanity-url`
+ */
+export type GetGuildVanityURL = { response: PartialInvite };
+
+/**
+ * Returns a PNG image widget for the guild. Requires no permissions or authentication.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/guild#get-guild-widget-image) `/guilds/{guild.id}/widget.png`
  */
 export interface GetWidgetImage {
-	/**
-	 * Style of the widget image returned.
-	 *
-	 * @defaultValue `shield`
-	 */
-	style?: WidgetStyle;
+	query: {
+		/**
+		 * Style of the widget image returned.
+		 *
+		 * @defaultValue `shield`
+		 */
+		style?: WidgetStyle;
+	};
+
+	response: unknown;
 }
 
 /**
@@ -1865,78 +2003,87 @@ export type WidgetStyle = 'shield' | 'banner1' | 'banner2' | 'banner3' | 'banner
  * Modify the discovery metadata for the guild. Requires the `MANAGE_GUILD` permission.
  *
  * @endpoint PATCH `/guilds/{guild.id}/discovery-metadata`
- *
- * @returns The updated discovery metadata object on success.
  */
 export interface ModifyDiscoveryMetadata {
-	/**
-	 * The ID of the primary discovery category.
-	 */
-	primary_category_id?: Nullable<number>;
+	body: {
+		/**
+		 * The ID of the primary discovery category.
+		 */
+		primary_category_id?: Nullable<number>;
+
+		/**
+		 * Up to 10 discovery search keywords.
+		 */
+		keywords?: Nullable<Partial<TupleOf<string, 10>>>;
+
+		/**
+		 * Whether guild info is shown when custom emojis are clicked.
+		 */
+		emoji_discoverability_enabled?: Nullable<boolean>;
+	};
 
 	/**
-	 * Up to 10 discovery search keywords.
+	 * The updated discovery metadata object.
 	 */
-	keywords?: Nullable<Partial<TupleOf<string, 10>>>;
-
-	/**
-	 * Whether guild info is shown when custom emojis are clicked.
-	 */
-	emoji_discoverability_enabled?: Nullable<boolean>;
+	response: DiscoveryMetadata;
 }
 
 /**
- * Modify the guild's [Welcome Screen][1]. Requires the `MANAGE_GUILD` permission.
+ * Modify the guild's Welcome Screen. Requires the `MANAGE_GUILD` permission.
  *
  * @endpoint PATCH `/guilds/{guild.id}/welcome-screen`
- *
- * @returns The updated [Welcome Screen][1] object.
- *
- * [1]: https://discord.com/developers/docs/resources/guild#welcome-screen-object
  */
 export interface ModifyWelcomeScreen {
-	/**
-	 * Whether the welcome screen is enabled.
-	 */
-	enabled: boolean;
+	body: {
+		/**
+		 * Whether the welcome screen is enabled.
+		 */
+		enabled: boolean;
+
+		/**
+		 * Channels linked in the welcome screen and their display options.
+		 */
+		welcome_channels: WelcomeScreenChannel[];
+
+		/**
+		 * The server description to show in the welcome screen.
+		 */
+		description: string;
+	};
 
 	/**
-	 * Channels linked in the welcome screen and their display options.
+	 * The updated Welcome Screen object.
 	 */
-	welcome_channels: WelcomeScreenChannel[];
-
-	/**
-	 * The server description to show in the welcome screen.
-	 */
-	description: string;
+	response: WelcomeScreen;
 }
 
 /**
- * Modify the guild's [Membership Screening][1] form. Requires the `MANAGE_GUILD` permission.
+ * Modify the guild's Membership Screening form. Requires the `MANAGE_GUILD` permission.
  *
  * @endpoint PATCH `/guilds/{guild.id}/member-verification`
- *
- * @returns The updated [Membership Screening][1] object.
- *
- * [1]: https://discord.com/developers/docs/resources/guild#membership-screening-object
  */
 export interface ModifyMembershipScreening {
-	/**
-	 * Whether Membership Screening is enabled.
-	 */
-	enabled?: boolean;
+	body: {
+		/**
+		 * Whether Membership Screening is enabled.
+		 */
+		enabled?: boolean;
+
+		/**
+		 * Array of field objects serialized in a string.
+		 */
+		form_fields?: string;
+
+		/**
+		 * The server description to show in the screening form.
+		 */
+		description?: string;
+	};
 
 	/**
-	 * Array of [field][1] objects serialized in a string.
-	 *
-	 * [1]: https://discord.com/developers/docs/resources/guild#membership-screening-object-membership-screening-field-structure
+	 * The updated Membership Screening object.
 	 */
-	form_fields?: string;
-
-	/**
-	 * The server description to show in the screening form.
-	 */
-	description?: string;
+	response: MembershipScreening;
 }
 
 // !SECTION

--- a/src/resources/Invite.ts
+++ b/src/resources/Invite.ts
@@ -1,5 +1,5 @@
 import { PartialApplication } from '../topics';
-import type { PartialChannel, PartialGuild, PartialUser, User } from './';
+import type { PartialChannel, PartialGuild, User } from './';
 
 // ANCHOR Partial Invite
 
@@ -107,18 +107,27 @@ export interface InviteMetadata extends Invite, Pick<PartialInvite, 'uses'> {
 // SECTION Endpoints
 
 /**
- * @endpoint [GET] `/invites/{invite.code}`
+ * Returns an invite object for the given code.
  *
- * @returns An [invite][1] object for the given code.
- *
- * [GET]: https://discord.com/developers/docs/resources/invite#invite-object
- * [1]: https://discord.com/developers/docs/resources/invite#invite-object
+ * @endpoint [GET](https://discord.com/developers/docs/resources/invite#invite-object) `/invites/{invite.code}`
  */
 export interface GetInvite {
-	/**
-	 * Whether the invite should contain approximate member counts.
-	 */
-	with_counts?: boolean;
+	query: {
+		/**
+		 * Whether the invite should contain approximate member counts.
+		 */
+		with_counts?: boolean;
+	};
+
+	response: Invite;
 }
+
+/**
+ * Delete an invite. Requires the `MANAGE_CHANNELS` permission on the channel this invite belongs
+ * to, or `MANAGE_GUILD` to remove any invite across the guild.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/invite#delete-invite) `/invites/{invite.code}`
+ */
+export type DeleteInvite = { response: Invite };
 
 // !SECTION

--- a/src/resources/Template.ts
+++ b/src/resources/Template.ts
@@ -1,5 +1,6 @@
 import type { Nullable } from '@api-typings/core';
 import type { PartialGuild, Snowflake, User } from '../';
+import { Guild } from './Guild';
 
 /**
  * Represents a code that when used, creates a guild based on a snapshot of an existing one.
@@ -66,74 +67,105 @@ export interface Template {
 // SECTION Endpoints
 
 /**
+ * Returns a template object for the given code.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/template#get-template) `/guilds/template/{template.code}`
+ */
+export type GetTemplate = { response: Template };
+
+/**
  * Create a new guild based on a template.
  *
  * @warning
  * This endpoint can be used only by bots in less than 10 guilds.
  *
- * @endpoint [POST] `/guilds/templates/{template.code}`
- *
- * @returns A [guild][1] object on success.
- * @fires A [Guild Create][2] Gateway event.
- *
- * [POST]: https://discord.com/developers/docs/resources/template#create-guild-from-template
- * [1]: https://discord.com/developers/docs/resources/guild#guild-object
- * [2]: https://discord.com/developers/docs/topics/gateway#guild-create
+ * @endpoint [POST](https://discord.com/developers/docs/resources/template#create-guild-from-template) `/guilds/templates/{template.code}`
  */
 export interface CreateGuildFromTemplate {
-	/**
-	 * Name of the guild (2-100 characters).
-	 */
-	name: string;
+	body: {
+		/**
+		 * Name of the guild (2-100 characters).
+		 */
+		name: string;
 
-	/**
-	 * Base64 128x128 image for the guild icon.
-	 */
-	icon?: string;
+		/**
+		 * Base64 128x128 image for the guild icon.
+		 */
+		icon?: string;
+	};
+
+	response: Guild;
 }
+
+/**
+ * Returns an array of template objects. Requires the MANAGE_GUILD permission.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/template#get-guild-templates) `/guilds/{guild.id}/templates`
+ */
+export type GetGuildTemplates = { response: Template[] };
 
 /**
  * Creates a template for the guild. Requires the `MANAGE_GUILD` permission.
  *
- * @endpoint [POST] `/guilds/{guild.id}/templates`
- *
- * @returns The created [template][1] object on success.
- *
- * [POST]: https://discord.com/developers/docs/resources/template#create-guild-template
- * [1]: https://discord.com/developers/docs/resources/template#template-object
+ * @endpoint [POST](https://discord.com/developers/docs/resources/template#create-guild-template) `/guilds/{guild.id}/templates`
  */
 export interface CreateGuildTemplate {
-	/**
-	 * Name of the template (1-100 characters).
-	 */
-	name: string;
+	body: {
+		/**
+		 * Name of the template (1-100 characters).
+		 */
+		name: string;
+
+		/**
+		 * Description for the template (0-120 characters).
+		 */
+		description?: Nullable<string>;
+	};
 
 	/**
-	 * Description for the template (0-120 characters).
+	 * The created template object.
 	 */
-	description?: Nullable<string>;
+	response: Template;
 }
+
+/**
+ * Syncs the template to the guild's current state. Requires the `MANAGE_GUILD` permission.
+ *
+ * @endpoint [PUT](https://discord.com/developers/docs/resources/template#get-guild-templates) `/guilds/{guild.id}/templates/{template.code}`
+ */
+export type SyncGuildTemplate = { response: Template };
 
 /**
  * Modifies the template's metadata. Requires the `MANAGE_GUILD` permission.
  *
- * @endpoint [PATCH] `/guilds/{guild.id}/templates/{template.code}`
- *
- * @returns The [template][1] object on success.
- *
- * [PATCH]: https://discord.com/developers/docs/resources/template#modify-guild-template
- * [1]: https://discord.com/developers/docs/resources/template#template-object
+ * @endpoint [PATCH](https://discord.com/developers/docs/resources/template#modify-guild-template) `/guilds/{guild.id}/templates/{template.code}`
  */
 export interface ModifyGuildTemplate {
-	/**
-	 * Name of the template (1-100 characters).
-	 */
-	name?: string;
+	body: {
+		/**
+		 * Name of the template (1-100 characters).
+		 */
+		name?: string;
 
-	/**
-	 * Description for the template (0-120 characters).
-	 */
-	description?: Nullable<string>;
+		/**
+		 * Description for the template (0-120 characters).
+		 */
+		description?: Nullable<string>;
+	};
+
+	response: Template;
 }
+
+/**
+ * Deletes the template. Requires the MANAGE_GUILD permission.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/resources/template#delete-guild-template) `/guilds/{guild.id}/templates/{template.code}`
+ */
+export type DeleteGuildTemplate = {
+	/**
+	 * The deleted template object.
+	 */
+	response: Template;
+};
 
 // !SECTION

--- a/src/resources/Voice.ts
+++ b/src/resources/Voice.ts
@@ -102,3 +102,14 @@ export interface VoiceRegion {
 	 */
 	custom: boolean;
 }
+
+// SECTION Endpoints
+
+/**
+ * Returns an array of voice region objects that can be used when creating servers.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/resources/voice#list-voice-regions) `/voice/regions`
+ */
+export type ListVoiceRegions = { response: VoiceRegion[] };
+
+// !SECTION

--- a/src/sdk/Achievements.ts
+++ b/src/sdk/Achievements.ts
@@ -148,34 +148,79 @@ export interface AchievementManager extends NodeJS.EventEmitter {
 // SECTION Endpoints
 
 /**
+ * Returns all achievements for the given application. This endpoint has a rate limit of 5
+ * requests per 5 seconds per application.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/achievements#get-achievements) `/applications/{application.id}/achievements`
+ */
+export type GetAchievements = { response: Achievement[] };
+
+/**
+ * Returns the given achievement for the given application. This endpoint has a rate limit of 5
+ * requests per 5 seconds per application.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/achievements#get-achievement) `/applications/{application.id}/achievements`
+ */
+export type GetAchievement = { response: Achievement };
+
+/**
  * Creates a new achievement for your application. Applications can have a maximum of 1000
  * achievements. This endpoint has a rate limit of 5 requests per 5 seconds per application.
  *
- * @endpoint [POST] `/applications/{application.id}/achievements`
- *
- * [POST]: https://discord.com/developers/docs/game-sdk/achievements#create-achievement
+ * @endpoint [POST](https://discord.com/developers/docs/game-sdk/achievements#create-achievement) `/applications/{application.id}/achievements`
  */
-export interface CreateAchievement extends Omit<Achievement, 'id' | 'icon_hash' | 'application_id'> {
-	/**
-	 * The icon for the achievement.
-	 */
-	icon: string;
+export interface CreateAchievement {
+	body: Omit<Achievement, 'id' | 'icon_hash' | 'application_id'> & {
+		/**
+		 * The icon for the achievement.
+		 */
+		icon: string;
+	};
+
+	response: Achievement;
 }
+
+/**
+ * Updates the achievement for **ALL USERS**. This is **NOT** to update a single user's achievement
+ * progress; this is to edit the UserAchievement itself. This endpoint has a rate limit of 5
+ * requests per 5 seconds per application.
+ *
+ * @endpoint [PATCH](https://discord.com/developers/docs/game-sdk/achievements#update-achievement) `/applications/{application.id}/achievements/{achievement.id}`
+ */
+export type UpdateAchievement = CreateAchievement;
+
+/**
+ * Deletes the given achievement from your application. This endpoint has a rate limit of 5
+ * requests per 5 seconds per application.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/game-sdk/achievements#delete-achievement) `/applications/{application.id}/achievements/{achievement.id}`
+ */
+export type DeleteAchievement = { response: never };
 
 /**
  * Updates the `UserAchievement` record for a given user. Use this endpoint to update secure
  * achievement progress for users. This endpoint has a rate limit of 5 requests per 5 seconds per
  * application.
  *
- * @endpoint [PUT] `/applications/{application.id}/achievements/{achievement.id}`
- *
- * [PUT]: https://discord.com/developers/docs/game-sdk/achievements#update-user-achievement
+ * @endpoint [PUT](https://discord.com/developers/docs/game-sdk/achievements#update-user-achievement) `/applications/{application.id}/achievements/{achievement.id}`
  */
 export interface UpdateUserAchievement {
-	/**
-	 * The user's progress towards completing the achievement.
-	 */
-	percent_complete: number;
+	body: {
+		/**
+		 * The user's progress towards completing the achievement.
+		 */
+		percent_complete: number;
+	};
+
+	response: never;
 }
+
+/**
+ * Returns a list of achievements for the user whose token you're making the request with. This
+ * endpoint has a rate limit of 2 requests per 5 seconds per application per user.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/achievements#get-user-achievements) `/applications/{application.id}/achievements`
+ */
+export type GetUserAchievements = { response: Achievement[] };
 
 // !SECTION

--- a/src/sdk/Lobbies.ts
+++ b/src/sdk/Lobbies.ts
@@ -1,4 +1,4 @@
-import type { Discord } from '../';
+import type { Discord, Snowflake } from '../';
 
 /**
  * @source {@link https://discord.com/developers/docs/game-sdk/lobbies#data-models-lobbytype-enum|Lobbies}
@@ -589,93 +589,106 @@ export interface LobbyManager extends NodeJS.EventEmitter {
 /**
  * Creates a new lobby.
  *
- * @endpoint [POST] `/lobbies`
- *
- * [POST]: https://discord.com/developers/docs/game-sdk/lobbies#create-lobby
+ * @endpoint [POST](https://discord.com/developers/docs/game-sdk/lobbies#create-lobby) `/lobbies`
  */
-export interface CreateLobby extends UpdateLobby {
-	/**
-	 * Your application ID.
-	 */
-	application_id: string;
+export interface CreateLobby {
+	body: UpdateLobby & {
+		/**
+		 * Your application ID.
+		 */
+		application_id: Snowflake;
 
-	/**
-	 * The region in which to make the lobby.
-	 *
-	 * @defaultValue The region of the requesting server's IP address
-	 */
-	region?: string;
+		/**
+		 * The region in which to make the lobby.
+		 *
+		 * @defaultValue The region of the requesting server's IP address
+		 */
+		region?: string;
+	};
+
+	response: CreateLobby['body'] & {
+		secret: string;
+		id: Snowflake;
+		owner_id: Snowflake;
+	};
 }
 
 /**
  * Updates a lobby.
  *
- * @endpoint [PATCH] `/lobbies/{lobby.id}`
- *
- * [PATCH]: https://discord.com/developers/docs/game-sdk/lobbies#update-lobby
+ * @endpoint [PATCH](https://discord.com/developers/docs/game-sdk/lobbies#update-lobby) `/lobbies/{lobby.id}`
  */
 export interface UpdateLobby {
-	/**
-	 * The type of lobby.
-	 */
-	type: LobbyType;
+	body: {
+		/**
+		 * The type of lobby.
+		 */
+		type: LobbyType;
 
-	/**
-	 * Metadata for the lobby–key/value pairs with types `string`.
-	 */
-	metadata: Record<string, string>;
+		/**
+		 * Metadata for the lobby–key/value pairs with types `string`.
+		 */
+		metadata: Record<string, string>;
 
-	/**
-	 * Max lobby capacity.
-	 *
-	 * @defaultValue 16
-	 */
-	capacity?: number;
+		/**
+		 * Max lobby capacity.
+		 *
+		 * @defaultValue 16
+		 */
+		capacity?: number;
+	};
 }
+
+/**
+ * Deletes a lobby.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/game-sdk/lobbies#delete-lobby) `/lobbies/{lobby.id}`
+ */
+export type DeleteLobby = { response: never };
 
 /**
  * Updates the metadata for a lobby member.
  *
- * @endpoint [PATCH] `/lobbies/{lobby.id}/members/{user.id}`
- *
- * [PATCH]: https://discord.com/developers/docs/game-sdk/lobbies#update-lobby-member
+ * @endpoint [PATCH](https://discord.com/developers/docs/game-sdk/lobbies#update-lobby-member) `/lobbies/{lobby.id}/members/{user.id}`
  */
 export interface UpdateLobbyMember {
-	/**
-	 * Metadata for the lobby member–key/value pairs with types `string`.
-	 */
-	metadata: Record<string, string>;
+	body: {
+		/**
+		 * Metadata for the lobby member–key/value pairs with types `string`.
+		 */
+		metadata: Record<string, string>;
+	};
 }
 
 /**
  * Creates a lobby search for matchmaking around given criteria.
  *
- * @endpoint [POST] `/lobbies/search`
- *
- * [POST]: https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search
+ * @endpoint [POST](https://discord.com/developers/docs/game-sdk/lobbies#create-lobby-search) `/lobbies/search`
  */
 export interface CreateLobbySearch {
-	/**
-	 * Your application ID.
-	 */
-	application_id: string;
+	body: {
+		/**
+		 * Your application ID.
+		 */
+		application_id: string;
 
-	/**
-	 * The filter to check against.
-	 */
-	filter: SearchFilter;
+		/**
+		 * The filter to check against.
+		 */
+		filter: SearchFilter;
 
-	/**
-	 * How to sort the results.
-	 */
-	sort: SearchSort;
+		/**
+		 * How to sort the results.
+		 */
+		sort: SearchSort;
 
-	/**
-	 * Limit of lobbies returned.
-	 *
-	 * @defaultValue 25
-	 */
-	limit?: number;
+		/**
+		 * Limit of lobbies returned.
+		 *
+		 * @defaultValue 25
+		 */
+		limit?: number;
+	};
 }
 
 /**
@@ -730,15 +743,15 @@ export interface SearchSort {
  * This endpoints accepts a UTF8 string. If you want to send binary, you can send it to this
  * endpoint as a base64 encoded data uri.
  *
- * @endpoint [POST] `/lobbies/{lobby.id}/send`
- *
- * [POST]: https://discord.com/developers/docs/game-sdk/lobbies#send-lobby-data|Lobbies
+ * @endpoint [POST](https://discord.com/developers/docs/game-sdk/lobbies#send-lobby-data|Lobbies) `/lobbies/{lobby.id}/send`
  */
 export interface SendLobbyData {
-	/**
-	 * A message to be sent to other lobby members.
-	 */
-	data: string;
+	body: {
+		/**
+		 * A message to be sent to other lobby members.
+		 */
+		data: string;
+	};
 }
 
 // !SECTION

--- a/src/sdk/Store.ts
+++ b/src/sdk/Store.ts
@@ -261,85 +261,128 @@ export interface LimitedPaymentData {
  * Gets entitlements for a given user. You can use this on your game backend to check entitlements
  * of an arbitrary user, or perhaps in an administrative panel for your support team.
  *
- * @endpoint [GET] `/applications/{application.id}/entitlements`
- *
- * [GET]: https://discord.com/developers/docs/game-sdk/store#get-entitlements
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/store#get-entitlements) `/applications/{application.id}/entitlements`
  */
 export interface GetEntitlements {
-	/**
-	 * The user ID to look up entitlements for.
-	 */
-	user_id?: Snowflake;
+	query: {
+		/**
+		 * The user ID to look up entitlements for.
+		 */
+		user_id?: Snowflake;
 
-	/**
-	 * The list SKU IDs to check entitlements for.
-	 */
-	sku_ids?: string;
+		/**
+		 * The list SKU IDs to check entitlements for.
+		 */
+		sku_ids?: string;
 
-	/**
-	 * Returns [limited payment data][1] for each entitlement.
-	 *
-	 * [1]: https://discord.com/developers/docs/game-sdk/store#httpspecific-data-models-limited-payment-data-object
-	 */
-	with_payments?: boolean;
+		/**
+		 * Returns limited payment data for each entitlement.
+		 */
+		with_payments?: boolean;
 
-	/**
-	 * Retrieve entitlements before this time.
-	 */
-	before?: Snowflake;
+		/**
+		 * Retrieve entitlements before this time.
+		 */
+		before?: Snowflake;
 
-	/**
-	 * Retrieve entitlements after this time.
-	 */
-	after?: Snowflake;
+		/**
+		 * Retrieve entitlements after this time.
+		 */
+		after?: Snowflake;
 
-	/**
-	 * Number of entitlements to return, 1-100.
-	 *
-	 * @defaultValue 100
-	 */
-	limit?: RangeOf<1, 100>;
+		/**
+		 * Number of entitlements to return, 1-100.
+		 *
+		 * @defaultValue 100
+		 */
+		limit?: RangeOf<1, 100>;
+	};
+
+	response: Entitlement[];
 }
 
 /**
  * Fetch an entitlement by its ID. This may be useful in confirming that a user has a given
  * entitlement that another call or the SDK says they do.
  *
- * @endpoint [GET] `/applications/{application.id}/entitlements/{entitlement.id}`
- *
- * [GET]: https://discord.com/developers/docs/game-sdk/store#get-entitlement
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/store#get-entitlement) `/applications/{application.id}/entitlements/{entitlement.id}`
  */
 export interface GetEntitlement {
-	/**
-	 * Returns [limited payment data][1] for the entitlement.
-	 *
-	 * [1]: https://discord.com/developers/docs/game-sdk/store#httpspecific-data-models-limited-payment-data-object
-	 */
-	with_payment?: boolean;
+	query: {
+		/**
+		 * Returns limited payment data for the entitlement.
+		 */
+		with_payment?: boolean;
+	};
+
+	response: Entitlement;
 }
+
+/**
+ * Get all SKUs for an application.
+ *
+ * @endpoint [GET](https://discord.com/developers/docs/game-sdk/store#get-skus) `/applications/{application.id}/skus`
+ */
+export type GetSKUs = { response: Sku[] };
+
+/**
+ * Marks a given entitlement for the user as consumed, meaning it will no longer be returned in an
+ * entitlements check.
+ *
+ * **Ensure the user was granted whatever items the entitlement was for before consuming it.**
+ *
+ * @endpoint [POST](https://discord.com/developers/docs/game-sdk/store#consume-sku) `/applications/{application.id}/entitlements/{entitlement.id}/consume`
+ */
+export type ConsumeSKU = { response: never };
+
+/**
+ * Deletes a test entitlement for an application.
+ *
+ * You can only delete entitlements that were "purchased" in developer test mode; these are
+ * entitlements of `type == TestModePurchase`. You cannot use this route to delete arbitrary
+ * entitlements that users actually purchased.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/game-sdk/store#delete-test-entitlement) `/applications/{application.id}/entitlements/{entitlement.id}`
+ */
+export type DeleteTestEntitlement = { response: never };
 
 /**
  * Creates a discount for the given user on their next purchase of the given SKU.
  *
  * @remarks
- * You should call this endpoint from your backend server just before calling [StartPurchase][1] for
- * the SKU you wish to discount. The user will then see a discounted price for that SKU at time of
+ * You should call this endpoint from your backend server just before calling StartPurchase for the
+ * SKU you wish to discount. The user will then see a discounted price for that SKU at time of
  * payment. The discount is automatically consumed after successful purchase or if the TTL expires.
  *
- * [1]: https://discord.com/developers/docs/game-sdk/store#start-purchase
+ * @endpoint [PUT](https://discord.com/developers/docs/game-sdk/store#create-purchase-discount) `/store/skus/{sku.id}/discounts/{user.id}`
  */
 export interface CreatePurchaseDiscount {
-	/**
-	 * The percentage to discount.
-	 */
-	percent_off: RangeOf<1, 100>;
+	body: {
+		/**
+		 * The percentage to discount.
+		 */
+		percent_off: RangeOf<1, 100>;
 
-	/**
-	 * The time to live for the discount, in seconds.
-	 *
-	 * @defaultValue 600
-	 */
-	ttl?: RangeOf<60, 3600>;
+		/**
+		 * The time to live for the discount, in seconds.
+		 *
+		 * @defaultValue 600
+		 */
+		ttl?: RangeOf<60, 3600>;
+	};
+
+	response: never;
 }
+
+/**
+ * Deletes the currently active discount on the given SKU for the given user.
+ *
+ * You **do not need** to call this after a user has made a discounted purchase; successful
+ * discounted purchases will automatically remove the discount for that user for subsequent
+ * purchases.
+ *
+ * @endpoint [DELETE](https://discord.com/developers/docs/game-sdk/store#delete-purchase-discount) `/store/skus/{sku.id}/discounts/{user.id}`
+ */
+export type DeletePurchaseDiscount = { response: never };
 
 // !SECTION


### PR DESCRIPTION
As opposed to creating multiple interfaces representing a different object related to the parent (e.g., a POST body, query, and response), each Endpoint interface will include the following fields:

```ts
interface APIRequest {
    query: {}
    body: {}
    response: {}
}
```

As a result, this will: 
- Add endpoints that were previously intentionally excluded, as they would've acted as type aliases (e.g.,  Get Channel)
- Remove all `@fires` and `@returns` JSDoc tags. Return annotations will now annotate the `response` field if it originally contained any important info
- Revert all endpoint links to hyperlink style (`[]()`)